### PR TITLE
Fix crash when no usb backend is available

### DIFF
--- a/whad/device/virtual/rfstorm/__init__.py
+++ b/whad/device/virtual/rfstorm/__init__.py
@@ -14,6 +14,9 @@ from threading import Thread, Lock
 from time import sleep, time
 from whad.helpers import swap_bits
 
+import logging
+logger = logging.getLogger(__name__)
+
 # Helpers functions
 def get_rfstorm(id=0,bus=None, address=None):
     '''
@@ -43,8 +46,12 @@ class RFStormDevice(VirtualDevice):
         Returns a list of available RFStorm devices.
         '''
         available_devices = []
-        for rfstorm in find(idVendor=RFStormId.RFSTORM_ID_VENDOR, idProduct=RFStormId.RFSTORM_ID_PRODUCT,find_all=True):
-            available_devices.append(RFStormDevice(bus=rfstorm.bus, address=rfstorm.address))
+        try:
+            for rfstorm in find(idVendor=RFStormId.RFSTORM_ID_VENDOR, idProduct=RFStormId.RFSTORM_ID_PRODUCT,find_all=True):
+                available_devices.append(RFStormDevice(bus=rfstorm.bus, address=rfstorm.address))
+        except ValueError as err:
+            logger.warning("Cannot access RFStorm, root privileges may be required.")
+            
         return available_devices
 
     @property

--- a/whad/device/virtual/rzusbstick/__init__.py
+++ b/whad/device/virtual/rzusbstick/__init__.py
@@ -14,6 +14,9 @@ from usb.util import get_string
 from struct import unpack, pack
 from time import sleep
 
+import logging
+logger = logging.getLogger(__name__)
+
 # Helpers functions
 def get_rzusbstick(id=0,bus=None, address=None):
     '''
@@ -42,8 +45,12 @@ class RZUSBStickDevice(VirtualDevice):
         Returns a list of available RZUSBStick devices.
         '''
         available_devices = []
-        for rzusbstick in find(idVendor=RZUSBStickId.RZUSBSTICK_ID_VENDOR, idProduct=RZUSBStickId.RZUSBSTICK_ID_PRODUCT,find_all=True):
-            available_devices.append(RZUSBStickDevice(bus=rzusbstick.bus, address=rzusbstick.address))
+        try:
+            for rzusbstick in find(idVendor=RZUSBStickId.RZUSBSTICK_ID_VENDOR, idProduct=RZUSBStickId.RZUSBSTICK_ID_PRODUCT,find_all=True):
+                available_devices.append(RZUSBStickDevice(bus=rzusbstick.bus, address=rzusbstick.address))
+        except ValueError as err:
+            logger.warning("Cannot access RZUSBStick, root privileges may be required.")
+            
         return available_devices
 
     @property

--- a/whad/device/virtual/yard/__init__.py
+++ b/whad/device/virtual/yard/__init__.py
@@ -17,7 +17,8 @@ from time import sleep,time
 from whad.helpers import swap_bits
 from queue import Queue, Empty
 
-
+import logging
+logger = logging.getLogger(__name__)
 
 # Helpers functions
 def get_yardstickone(id=0,bus=None, address=None):
@@ -47,8 +48,12 @@ class YardStickOneDevice(VirtualDevice):
         Returns a list of available RZUSBStick devices.
         '''
         available_devices = []
-        for yard in find(idVendor=YardStickOneId.YARD_ID_VENDOR, idProduct=YardStickOneId.YARD_ID_PRODUCT,find_all=True):
-            available_devices.append(YardStickOneDevice(bus=yard.bus, address=yard.address))
+        try:
+            for yard in find(idVendor=YardStickOneId.YARD_ID_VENDOR, idProduct=YardStickOneId.YARD_ID_PRODUCT,find_all=True):
+                available_devices.append(YardStickOneDevice(bus=yard.bus, address=yard.address))
+        except ValueError as err:
+            logger.warning("Cannot access YardStickOne, root privileges may be required.")
+
         return available_devices
 
     @property


### PR DESCRIPTION
For various reasons the USB backend may not be available.  Don't crash when this occurs (matches existing Ubertooth behavior).