### PR TITLE
Allow wsniff to run on MacOS

### DIFF
--- a/whad/device/uart.py
+++ b/whad/device/uart.py
@@ -89,7 +89,7 @@ class UartDevice(WhadDevice):
         if port_info is None:
             raise WhadDeviceNotFound
         else:
-            self.__is_acm = (port_info.subsystem == 'usb')
+            self.__is_acm = (port_info.usb_info is not None)
 
     @property
     def identifier(self):

--- a/whad/device/virtual/hci/hciconfig.py
+++ b/whad/device/virtual/hci/hciconfig.py
@@ -14,12 +14,16 @@ class HCIConfig(object):
 
     @classmethod
     def list(cls):
-        sock = socket(31, SOCK_RAW, 1)
+        # if raw HCI socket is not available, return an empty list
+        try:
+            sock = socket(31, SOCK_RAW, 1)
 
-        # Get number of devices
-        arg = pack('I', 16) +  b"\x00" * (8*16)
-        output = ioctl(sock.fileno(), cls.HCIGETDEVLIST, arg)
-        number_of_devices = unpack('H', output[:2])[0]
+            # Get number of devices
+            arg = pack('I', 16) +  b"\x00" * (8*16)
+            output = ioctl(sock.fileno(), cls.HCIGETDEVLIST, arg)
+            number_of_devices = unpack('H', output[:2])[0]
+        except Exception:
+            number_of_devices = 0
 
         device_ids = []
         for device_number in range(number_of_devices):


### PR DESCRIPTION
Raw HCI sockets are not available so wrap with a try. port_info.subsystem is not available on MacOS so check port_info.usb_info instead