### PR TITLE
Removed wzb-enddevice logging configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ testpaths = [
 name = "whad"
 
 # Attention: the following version number must match the one in whad/version.py !
-version = "1.2.1"
+version = "1.2.2"
 
 authors = [
     { name="Damien CAUQUIL" },

--- a/whad/__init__.py
+++ b/whad/__init__.py
@@ -15,8 +15,6 @@ logging.getLogger("scapy.runtime").setLevel(logging.ERROR)
 
 
 __all__ = [
-    'Domain',
-    'Capability',
     'UartDevice',
     'VirtualDevice',
     'RequiredImplementation',

--- a/whad/__init__.py
+++ b/whad/__init__.py
@@ -15,6 +15,8 @@ logging.getLogger("scapy.runtime").setLevel(logging.ERROR)
 
 
 __all__ = [
+    'Domain',
+    'Capability',
     'UartDevice',
     'VirtualDevice',
     'RequiredImplementation',

--- a/whad/version.py
+++ b/whad/version.py
@@ -6,7 +6,7 @@ ATTENTION: This version number must match the one in pyproject.toml !
 # Current version number
 VERSION_MAJOR = 1
 VERSION_MINOR = 2
-VERSION_REVISION = 1
+VERSION_REVISION = 2
 
 def get_version() -> str:
     """Return the current version of this package (WHAD).

--- a/whad/zigbee/cli/enddevice/shell.py
+++ b/whad/zigbee/cli/enddevice/shell.py
@@ -22,6 +22,12 @@ from .helpers import create_enddevice
 INTRO='''
 zigbee-enddevice, the WHAD Zigbee end device utility
 '''
+import logging
+logging.getLogger("whad.zigbee.stack.nwk").setLevel(logging.DEBUG)
+logging.getLogger("whad.dot15d4.stack.mac").setLevel(logging.DEBUG)
+logging.getLogger("whad.zigbee.stack.apl.zdo.discovery").setLevel(logging.DEBUG)
+
+logging.basicConfig(level=logging.ERROR)
 
 class ZigbeeEndDeviceShell(InteractiveShell):
     """Zigbee End Device interactive shell

--- a/whad/zigbee/cli/enddevice/shell.py
+++ b/whad/zigbee/cli/enddevice/shell.py
@@ -22,12 +22,6 @@ from .helpers import create_enddevice
 INTRO='''
 zigbee-enddevice, the WHAD Zigbee end device utility
 '''
-import logging
-logging.getLogger("whad.zigbee.stack.nwk").setLevel(logging.DEBUG)
-logging.getLogger("whad.dot15d4.stack.mac").setLevel(logging.DEBUG)
-logging.getLogger("whad.zigbee.stack.apl.zdo.discovery").setLevel(logging.DEBUG)
-
-logging.basicConfig(level=logging.ERROR)
 
 class ZigbeeEndDeviceShell(InteractiveShell):
     """Zigbee End Device interactive shell


### PR DESCRIPTION
A debugging logging configuration has inadvertently been left in `wzb-enddevice` in the recent rush for our BruCON workshop.