### PR TITLE
Fixed HCI driver disconnection procedure to avoid hangs (issue #50)

### DIFF
--- a/whad/ble/connector/__init__.py
+++ b/whad/ble/connector/__init__.py
@@ -604,7 +604,7 @@ class BLE(WhadDeviceConnector):
 
         :param int conn_handle: Connection handle of the connection to terminate.
         """
-
+        logger.debug("[ble] sending Disconnect message")
         # Create a Disconnect message
         msg = self.hub.ble.create_disconnect(conn_handle)
 
@@ -689,16 +689,21 @@ class BLE(WhadDeviceConnector):
         :param event: WHAD event to process
         :type event: :class:`whad.hub.events.WhadEvent`
         """
+
         # Don't process if connector is not ready
         if not self.__ready:
+            logger.debug("[ble connector] on_event() called, but connector is not ready")
             return
 
         # Dispatch event
         if isinstance(event, ConnectionEvt):
+            logger.debug("[ble connector] on_event() called: connection event")
             self.on_connected(event)
         elif isinstance(event, DisconnectionEvt):
+            logger.debug("[ble connector] on_event() called: disconnection event")
             self.on_disconnected(event)
         elif isinstance(event, SyncEvt):
+            logger.debug("[ble connector] on_event() called: sync event")
             self.on_synchronized(
                 access_address = event.access_address,
                 crc_init = event.crc_init,
@@ -707,9 +712,13 @@ class BLE(WhadDeviceConnector):
                 channel_map = event.channel_map
             )
         elif isinstance(event, DesyncEvt):
+            logger.debug("[ble connector] on_event() called: desync event")
             self.on_desynchronized(access_address=event.access_address)
         elif isinstance(event, TriggeredEvt):
+            logger.debug("[ble connector] on_event() called: triggered event")
             self.on_triggered(event.id)
+        else:
+            logger.error("[ble connector] on_event() called: unknown event !")
 
     def on_packet(self, packet: Packet):
         """Dispatch incoming packet.

--- a/whad/ble/connector/central.py
+++ b/whad/ble/connector/central.py
@@ -214,6 +214,7 @@ class Central(BLE):
         :param  disconnection_data: Disconnection data
         :type   disconnection_data: :class:`whad.protocol.ble_pb2.Disconnected`
         """
+        logger.debug("[central] Device disconnected, forward to stack")
         self.__stack.on_disconnection(
             disconnection_data.conn_handle,
             disconnection_data.reason
@@ -224,6 +225,7 @@ class Central(BLE):
         self.__target = None
 
         # Notify peripheral device about this disconnection
+        logger.debug("[central] Notify peripheral object that a disconnection occurred")
         if self.__peripheral is not None:
             self.__peripheral.on_disconnect(disconnection_data.conn_handle)
 

--- a/whad/cli/app.py
+++ b/whad/cli/app.py
@@ -726,11 +726,13 @@ def run_app(application: CommandLineApp):
     except KeyboardInterrupt:
         application.warning("Interrupted by user (CTL-C)")
     except WhadDeviceTimeout:
-        application.error("WHAD adapter has timed out.")
+        application.error("WHAD interface has timed out.")
+    except WhadDeviceNotReady:
+        application.error("WHAD interface seems unresponsive.")
     except WhadDeviceAccessDenied:
-        application.error("Cannot access WHAD adapter, check permissions.")
+        application.error("Cannot access WHAD interface, check permissions.")
     except UnsupportedDomain as domain_err:
-        application.error("WHAD adapter does not support %s." % domain_err.domain)
+        application.error("WHAD interface does not support %s." % domain_err.domain)
     except Exception as exc:
         application.error("An unexpected exception occured:")
         traceback.print_exception(exc)

--- a/whad/device/uart.py
+++ b/whad/device/uart.py
@@ -235,6 +235,13 @@ class UartDevice(WhadDevice):
         # Handle incoming messages if any
         if len(readers) > 0 and self.__fileno is not None:
             data = os.read(self.__fileno, 1024)
+
+            # Make sure data is not empty (detect device disconnection/malfunction)
+            if len(data) == 0 :
+                # Device does not behave as expected, may not be ready.
+                raise WhadDeviceNotReady()
+            
+            # Feed our IO thread with received data
             self.on_data_received(data)
 
     def change_transport_speed(self, speed):

--- a/whad/device/virtual/hci/__init__.py
+++ b/whad/device/virtual/hci/__init__.py
@@ -103,7 +103,6 @@ class HCIDevice(VirtualDevice):
         self.__timeout = 1.0
         self._connected = False
         self._active_handles = []
-        self._waiting_disconnect = False
 
     @property
     def identifier(self):
@@ -183,7 +182,7 @@ class HCIDevice(VirtualDevice):
                     # If the connection is stopped and peripheral mode is started,
                     # automatically re-enable advertising based on cached data
                     if HCI_Event_Disconnection_Complete in event:
-                        self._waiting_disconnect = False
+                        logger.debug("[hci] Disconnection complete")
                     if HCI_Event_Disconnection_Complete in event and self.__internal_state == HCIInternalState.PERIPHERAL:
                         # If advertising was not enabled, skip
                         if not self._advertising:
@@ -486,10 +485,8 @@ class HCIDevice(VirtualDevice):
         """
         Establish a disconnection using HCI device.
         """
+        logger.debug("[hci] sending HCI disconnect command ...")
         response = self._write_command(HCI_Cmd_Disconnect(handle=handle))
-        self._waiting_disconnect = True
-        while self._waiting_disconnect:
-            sleep(0.1)
         return response is not None and response.status == 0x00
 
     def _set_advertising_data(self, data, wait_response=True):

--- a/whad/device/virtual/hci/converter.py
+++ b/whad/device/virtual/hci/converter.py
@@ -202,6 +202,7 @@ class HCIConverter:
             processed = False
             conn_handle = event.handle
 
+            logger.debug("[hci] received PDU from remote device, forwarding to host")
             msg = self.__device.hub.ble.create_pdu_received(
                 direction,
                 raw(pdu),
@@ -274,6 +275,7 @@ class HCIConverter:
             self.__device._active_handles.remove(event.handle)
 
             # Send disconnection message to consumer.
+            logger.debug("[hci] sending Disconnect message to host")
             msg = self.__device.hub.ble.create_disconnected(
                 event.reason,
                 event.handle


### PR DESCRIPTION
WHAD python HCI driver hanged during disconnection when a remote device sent a huge number of data PDU, delaying the disconnection notification. Based on our WHAD protocol, disconnection request must be answered immediately, even if the disconnection process takes some time to complete.