### PR TITLE
Fixed LoRa syncword

### DIFF
--- a/whad/phy/connector/lora.py
+++ b/whad/phy/connector/lora.py
@@ -13,8 +13,8 @@ class LoRa(Phy):
     '''LoRa modulation/demodulation connector.
     '''
 
-    SYNCWORD_M2M = b'\x24\x14'
-    SYNCWORD_LORAWAN = b'\x44\x34'
+    SYNCWORD_M2M = b'\x12'
+    SYNCWORD_LORAWAN = b'\x34'
 
     domain = "lora"
 


### PR DESCRIPTION
Moved from 2-byte long synchronization word to 1-byte sync word (originally, this was a mistake because STM32WLxx platform uses a 2-byte long sync word for LoRa while the specifications clearly states it must be a single byte