### PR TITLE
Fixed multiple bugs in active connection sniffing (issue #74)

### DIFF
--- a/examples/ble/ble_existing_connection_sniffer.py
+++ b/examples/ble/ble_existing_connection_sniffer.py
@@ -1,4 +1,5 @@
 from whad.ble import Sniffer
+from whad.hub.ble import ChannelMap
 from whad.ble.connector.sniffer import SynchronizedConnection
 from whad.device import WhadDevice
 from whad.exceptions import WhadDeviceNotFound
@@ -21,7 +22,7 @@ if __name__ == '__main__':
                 active_connection = SynchronizedConnection(
                         access_address=0x9096cd63,
                         crc_init=0xa4f31c,
-                        channel_map=bytes.fromhex("ffefffff1f")
+                        channel_map=ChannelMap.from_bytes(bytes.fromhex("ffefffff1f"))
                 )
             )
             

--- a/whad/ble/connector/sniffer.py
+++ b/whad/ble/connector/sniffer.py
@@ -275,20 +275,20 @@ class Sniffer(BLE, EventsManager):
                 elif self.__configuration.active_connection is not None:
                     message = self.wait_for_message(filter=message_filter(Synchronized), timeout=0.1)
 
-                    # TODO : improve the switch
-                    if message.hop_increment > 0:
-                        if self.support_raw_pdu():
-                            message_type = BleRawPduReceived
-                        elif self.__synchronized:
-                            message_type = BlePduReceived
-                        else:
-                            message_type = BleAdvPduReceived
+                    if message is not None:
+                        if message.hop_increment > 0:
+                            if self.support_raw_pdu():
+                                message_type = BleRawPduReceived
+                            elif self.__synchronized:
+                                message_type = BlePduReceived
+                            else:
+                                message_type = BleAdvPduReceived
 
-                        message = self.wait_for_message(filter=message_filter(message_type), timeout=0.1)
-                        if message is not None:
-                            packet = message.to_packet()
-                            self.monitor_packet_rx(packet)
-                            yield packet
+                            message = self.wait_for_message(filter=message_filter(message_type), timeout=0.1)
+                            if message is not None:
+                                packet = message.to_packet()
+                                self.monitor_packet_rx(packet)
+                                yield packet
 
                 else:
                     if self.support_raw_pdu():

--- a/whad/ble/sniffing.py
+++ b/whad/ble/sniffing.py
@@ -2,6 +2,7 @@ from whad.ble.exceptions import InvalidAccessAddressException
 from dataclasses import dataclass, field
 from whad.ble.utils.phy import is_access_address_valid
 from whad.common.sniffing import SniffingEvent
+from whad.hub.ble import ChannelMap
 
 @dataclass
 class SynchronizedConnection:
@@ -9,7 +10,7 @@ class SynchronizedConnection:
     crc_init : int = None
     hop_interval : int = None
     hop_increment : int = None
-    channel_map : bytes = None
+    channel_map : ChannelMap = None
 
 class ConnectionConfiguration(SynchronizedConnection):
     """
@@ -35,7 +36,7 @@ class SynchronizationEvent(SniffingEvent):
                     "0x{:06x}".format(self.synchronized_connection.crc_init),
                     str(self.synchronized_connection.hop_interval), str(self.synchronized_connection.hop_interval*1250),
                     str(self.synchronized_connection.hop_increment),
-                    "0x"+self.synchronized_connection.channel_map.hex()
+                    "0x"+self.synchronized_connection.channel_map.value.hex()
         )
 
 


### PR DESCRIPTION
This PR fixes issue #74.

* Active connection sniffing example code did not use ChannelMap but a bytes array instead while the API was waiting for a ChannelMap instance
* A call to `wait_for_message()` did not check if the returned value was `None`, causing an exception when trying to access one of its parameter.