### PR TITLE
Add example code for LoRa connector in documentation (issue #81)

### DIFF
--- a/doc/source/phy/derived.rst
+++ b/doc/source/phy/derived.rst
@@ -12,5 +12,30 @@ wrapper for the underlying LoRa modulation. This connector will automatically
 enables this modulation but also provides methods to configure a LoRa receiver
 or transmitter, as well as sniffing packets.
 
+For instance, to configure a LoRa interface for sniffing:
+
+.. code-block:: python
+
+    from whad.device import WhadDevice
+    from whad.phy.connector.lora import LoRa
+
+    # Create our device
+    device = WhadDevice.create("uart0")
+
+    # Create our LoRa connector
+    lora = LoRa(device)
+
+    # Configure our LoRa sniffer
+    lora.sf = 7
+    lora.cr = 45
+    lora.bw = 250000
+    lora.preamble_length = 12
+    lora.syncword = b"\x12"
+    lora.enable_crc(True)
+    lora.enable_explicit_mode(True)
+
+    # Start sniffing
+    lora.start()
+
 .. automodule:: whad.phy.connector.lora
     :members:


### PR DESCRIPTION
Documentation now includes an example code demonstrating how to initialize and configure a `LoRa` connector for sniffing, since it is not intuitive. We'll have a look later at this implementation and make it easier to use.