### PR TITLE
Added control of LoRa preamble length in `wsniff` (issue #87)

### DIFF
--- a/whad/phy/connector/sniffer.py
+++ b/whad/phy/connector/sniffer.py
@@ -56,7 +56,7 @@ class Sniffer(Phy, EventsManager):
                 self.__configuration.lora_configuration.spreading_factor,
                 self.__configuration.lora_configuration.coding_rate,
                 self.__configuration.lora_configuration.bandwidth,
-                12,
+                self.__configuration.lora_configuration.preamble_length,
                 crc=self.__configuration.lora_configuration.enable_crc,
                 explicit=self.__configuration.lora_configuration.enable_explicit_mode
             )

--- a/whad/phy/sniffing.py
+++ b/whad/phy/sniffing.py
@@ -20,12 +20,14 @@ class LoRaConfiguration:
     :param bandwidth: select the bandwidth (bw)
     :param enable_crc: enable LoRa CRC (crc)
     :param enable_explicit_mode: enable LoRa explicit mode (em)
+    :param preamble_length: set LoRa preamble length in symbols (pl)
     """
     spreading_factor : int = 7
     coding_rate : int = 45
     bandwidth : int = 125000
     enable_crc: bool = False
     enable_explicit_mode: bool = False
+    preamble_length: int = 12
 
 
 @dataclass


### PR DESCRIPTION
Modified PHY's sniffing configuration to include LoRa preamble length, this exposes a new parameter in `wsniff` when using the PHY domain.