### PR TITLE
Add support for forced association to wzb-enddevice

### DIFF
--- a/whad/zigbee/cli/enddevice/shell.py
+++ b/whad/zigbee/cli/enddevice/shell.py
@@ -253,13 +253,21 @@ class ZigbeeEndDeviceShell(InteractiveShell):
             )
 
             # Perform join
-            target['info'].join(force=force)
+            result = target['info'].join(force=force)
 
-            print("Successfully joined to target network (PAN ID = %s / Ext. PAN ID = %s)." % (
-                    hex(target['info'].pan_id),
-                    str(Dot15d4Address(target['info'].extended_pan_id))
+            if result:
+                print("Successfully joined to target network (PAN ID = %s / Ext. PAN ID = %s)." % (
+                        hex(target['info'].pan_id),
+                        str(Dot15d4Address(target['info'].extended_pan_id))
+                    )
                 )
-            )
+            else:
+                print("Failed to join target network (PAN ID = %s / Ext. PAN ID = %s)." % (
+                        hex(target['info'].pan_id),
+                        str(Dot15d4Address(target['info'].extended_pan_id))
+                    )
+                )
+
             if target['info'].network_key is not None:
                 print_formatted_text(HTML('<ansicyan><b>Network key:</b></ansicyan> %s' % target['info'].network_key.hex()))
 

--- a/whad/zigbee/cli/enddevice/shell.py
+++ b/whad/zigbee/cli/enddevice/shell.py
@@ -190,14 +190,22 @@ class ZigbeeEndDeviceShell(InteractiveShell):
     def do_join(self, args):
         """join a network
 
-        <ansicyan><b>join</b> <i>[ Extended PAN ID or PAN ID ]</i> ([force])</ansicyan>
+        <ansicyan><b>join</b> <i>[ Extended PAN ID or PAN ID ] (force)</i></ansicyan>
 
         Initiate a ZigBee join to a specific network by its extended PAN ID or
         PAN ID. If multiple networks have the same PAN ID, the first one will be
         picked for join.
 
+        Example:
+
+            <i>    zigbee-enddevice> join 0x1234</i>
+
         Joining a network that des not permit association is possible by using the
         optional <i>force</i> parameter.
+
+        Example:
+
+            <i>    zigbee-enddevice> join 0x1234 force</i>
         """
 
         if len(args) < 1:

--- a/whad/zigbee/cli/enddevice/shell.py
+++ b/whad/zigbee/cli/enddevice/shell.py
@@ -262,7 +262,7 @@ class ZigbeeEndDeviceShell(InteractiveShell):
                     )
                 )
             else:
-                print("Failed to join target network (PAN ID = %s / Ext. PAN ID = %s)." % (
+                self.error("Failed to join target network (PAN ID = %s / Ext. PAN ID = %s)." % (
                         hex(target['info'].pan_id),
                         str(Dot15d4Address(target['info'].extended_pan_id))
                     )

--- a/whad/zigbee/cli/enddevice/shell.py
+++ b/whad/zigbee/cli/enddevice/shell.py
@@ -190,11 +190,14 @@ class ZigbeeEndDeviceShell(InteractiveShell):
     def do_join(self, args):
         """join a network
 
-        <ansicyan><b>join</b> <i>[ Extended PAN ID or PAN ID ]</i> </ansicyan>
+        <ansicyan><b>join</b> <i>[ Extended PAN ID or PAN ID ]</i> ([force])</ansicyan>
 
         Initiate a ZigBee join to a specific network by its extended PAN ID or
         PAN ID. If multiple networks have the same PAN ID, the first one will be
         picked for join.
+
+        Joining a network that des not permit association is possible by using the
+        optional <i>force</i> parameter.
         """
 
         if len(args) < 1:
@@ -203,12 +206,13 @@ class ZigbeeEndDeviceShell(InteractiveShell):
 
         #try:
         target = None
+        force = len(args) >= 2 and args[1].lower() == "force"
 
         try:
             target = self.__cache[args[0]]
             target_pan_id = Dot15d4Address(target['info'].extended_pan_id)
 
-        except IndexError as notfound:
+        except IndexError:
             # If target not in cache, we are expecting an extended PAN ID or a PAN ID
             try:
                 target_pan_id = Dot15d4Address(args[0])
@@ -247,7 +251,10 @@ class ZigbeeEndDeviceShell(InteractiveShell):
                 target['info'].channel
                 )
             )
-            target['info'].join()
+
+            # Perform join
+            target['info'].join(force=force)
+
             print("Successfully joined to target network (PAN ID = %s / Ext. PAN ID = %s)." % (
                     hex(target['info'].pan_id),
                     str(Dot15d4Address(target['info'].extended_pan_id))

--- a/whad/zigbee/profile/network.py
+++ b/whad/zigbee/profile/network.py
@@ -3,6 +3,9 @@ from whad.zigbee.profile.nodes import CoordinatorNode, EndDeviceNode, RouterNode
 from whad.dot15d4.address import Dot15d4Address
 from random import randint
 from time import sleep
+import logging
+
+logger = logging.getLogger(__name__)
 
 class JoiningForbidden(Exception):
     """
@@ -98,11 +101,15 @@ class Network:
         :type force: bool
         """
         if self.is_joining_permitted() or force:
-            join_success = self.stack.get_layer('apl').get_application_by_name("zdo").network_manager.join(self)
+            logger.debug("Start joining network (force=%s)", force)
+            join_success = self.stack.get_layer('apl').get_application_by_name("zdo").network_manager.join(self, force=force)
             if join_success:
                 while not self.is_authorized():
                     sleep(0.1)
+                logger.debug("Successfully joined network")
                 return True
+            
+            logger.debug("Failed joining network")
             return False
         else:
             raise JoiningForbidden

--- a/whad/zigbee/profile/network.py
+++ b/whad/zigbee/profile/network.py
@@ -88,13 +88,16 @@ class Network:
         devices = self.stack.get_layer('apl').get_application_by_name("zdo").device_and_service_discovery.discover_nodes()
         return self.nodes
 
-    def join(self):
+    def join(self, force: bool = False):
         """
         Join the network (if permitted).
 
         This method is blocking and wait until we are both associated AND authorized on the network.
+
+        :param force: If set to `True`, join network even if association is not allowed.
+        :type force: bool
         """
-        if self.is_joining_permitted():
+        if self.is_joining_permitted() or force:
             join_success = self.stack.get_layer('apl').get_application_by_name("zdo").network_manager.join(self)
             if join_success:
                 while not self.is_authorized():

--- a/whad/zigbee/stack/apl/zdo/network/__init__.py
+++ b/whad/zigbee/stack/apl/zdo/network/__init__.py
@@ -131,7 +131,7 @@ class ZDONetworkManager(ZDOObject):
                         )
         return networks.values()
 
-    def join(self, network):
+    def join(self, network, force: bool = False):
         """
         Join a specific network.
         """
@@ -152,12 +152,14 @@ class ZDONetworkManager(ZDOObject):
         join_success = nwk_management.join(
             apsUseExtendedPANID,
             association_type=NWKJoinMode.NEW_JOIN,
-            scan_channels=apsChannelMask
+            scan_channels=apsChannelMask,
+            force=force
         )
         if not join_success:
             logger.info("[zdo_network_manager] failure during network join, exiting.")
             return False
 
+        logger.debug("[zdo_network_manager] successfully joined network.")
         self.network = network
         return True
 

--- a/whad/zigbee/stack/nwk/__init__.py
+++ b/whad/zigbee/stack/nwk/__init__.py
@@ -278,7 +278,7 @@ class NWKManagementService(NWKService):
 
 
     @Dot15d4Service.request("NLME-JOIN")
-    def join(self, extended_pan_id, association_type=NWKJoinMode.NEW_JOIN, scan_channels=0x7fff800, scan_duration=4, join_as_router=False, rx_on_when_idle=True, mains_powered_device=False, security_enable=False):
+    def join(self, extended_pan_id, association_type=NWKJoinMode.NEW_JOIN, scan_channels=0x7fff800, scan_duration=4, join_as_router=False, rx_on_when_idle=True, mains_powered_device=False, security_enable=False, force=False):
         """
         Implements the NLME-JOIN request.
 
@@ -290,7 +290,8 @@ class NWKManagementService(NWKService):
             table = self.database.get("nwkNeighborTable")
 
             while True:
-                candidate_parents = table.select_suitable_parent(extended_pan_id, self.database.get("nwkUpdateId"))
+                candidate_parents = table.select_suitable_parent(extended_pan_id, self.database.get("nwkUpdateId"),
+                                                                no_permit_check=force)
                 if len(candidate_parents) == 0:
                     return False
 
@@ -335,6 +336,7 @@ class NWKManagementService(NWKService):
                     security_capability=False,
                     fast_association=False
                 ):
+                    logger.debug("[nwk_management_service] association is successful")
                     # Update database according to successful association
                     macShortAddress = self.manager.get_layer('mac').database.get("macShortAddress")
                     self.database.set("nwkNetworkAddress", macShortAddress)
@@ -347,6 +349,7 @@ class NWKManagementService(NWKService):
                         nwkAddressMap[selected_parent.extended_address] = selected_parent.address
                     return True
                 else:
+                    logger.debug("[nwk_management_service] association is unsuccessful")
                     selected_parent.potential_parent = 0
 
         # In the case of a rejoin


### PR DESCRIPTION
This small modification allows a user to perform a network join operation on an existing ZigBee network even if it does not permit association. This is achieved thanks to an optional argument passed to the interactive shell `join` command as shown below:

```
zigbee-enddevice> join 0x1234 force
```