### PR TITLE
Fixed `wshark` hanging issue

### DIFF
--- a/whad/common/monitors/wireshark.py
+++ b/whad/common/monitors/wireshark.py
@@ -66,6 +66,14 @@ class WiresharkMonitor(PcapWriterMonitor):
                 dissector_name = conf_line.split("Proto(")[1].split(",")[0].replace("\"", "")
             self._wireshark_process = Popen([self._wireshark_path,"-X","lua_script:"+dissector,"-o","uat:user_dlts:\"User 1 (DLT=148)\",\""+dissector_name+"\",\"\",\"\",\"\",\"\"", "-k", "-i", fifo], stderr=DEVNULL, stdout=DEVNULL)
 
+    def is_terminated(self) -> bool:
+        """Check if wireshark process has terminated.
+
+        :return: `True` if process has terminated, `False` otherwise
+        :rtype: bool
+        """
+        return self._wireshark_process.poll() is not None
+
     def close(self):
         self._writer_lock.acquire()
         if hasattr(self, "_writer") and self._writer is not None:

--- a/whad/tools/wshark.py
+++ b/whad/tools/wshark.py
@@ -97,7 +97,8 @@ class WhadWiresharkApp(CommandLineApp):
                     while interface.opened:
                         time.sleep(.1)
                 else:
-                    while interface.opened:
+                    # Loop until interface or wireshark is closed
+                    while interface.opened and not self.monitor.is_terminated():
                         wait("Forwarding {count} packets to wireshark".format(
                                 count=str(self.monitor.packets_written)
                             )

--- a/whad/tools/wshark.py
+++ b/whad/tools/wshark.py
@@ -3,6 +3,7 @@
 This utility implements a server module, allowing to create a TCP proxy
 which can be used to access a device remotely.
 """
+import sys
 import logging
 import time
 
@@ -93,8 +94,8 @@ class WhadWiresharkApp(CommandLineApp):
                 self.monitor.start()
 
                 if self.is_stdout_piped():
-                    # Wait for the user to CTL-C
-                    while interface.opened:
+                    # Wait for the user to CTL-C or wireshark to be closed
+                    while interface.opened and not self.monitor.is_terminated():
                         time.sleep(.1)
                 else:
                     # Loop until interface or wireshark is closed
@@ -105,12 +106,12 @@ class WhadWiresharkApp(CommandLineApp):
                         )
                         time.sleep(.2)
 
-
         except KeyboardInterrupt:
             # Launch post-run tasks
             if self.monitor is not None:
                 self.monitor.stop()
                 self.monitor.close()
+        finally:
             self.post_run()
 
     def post_run(self):


### PR DESCRIPTION
when using `wshark`, a wireshark user-interface is launched but when closed `wshark` remained active. Added some code to detect when wireshark is closed and exit `wshark`. 