### PR TITLE
Fixed a wshark crash when input device fails to connect

### DIFF
--- a/whad/tools/wshark.py
+++ b/whad/tools/wshark.py
@@ -115,7 +115,7 @@ class WhadWiresharkApp(CommandLineApp):
             self.post_run()
 
     def post_run(self):
-        if not self.is_stdout_piped():
+        if not self.is_stdout_piped() and self.monitor is not None:
             wait("Forwarding {count} packets to wireshark".format(
                     count=str(self.monitor.packets_written)
                 ),


### PR DESCRIPTION
wshark post_run() function did not correctly check that Wireshark has correctly been intialized before accessing some properties.