### PR TITLE
Fixed bugs in wble-periph that caused multiple crashes

### DIFF
--- a/whad/ble/cli/peripheral/shell.py
+++ b/whad/ble/cli/peripheral/shell.py
@@ -692,10 +692,13 @@ class BlePeriphShell(InteractiveShell):
             
             # Search characteristic by its handle
             if self.__profile is not None:
-                charac = self.__profile.find_object_by_handle(handle_uuid)
-                if isinstance(charac, Characteristic):
-                    # Update value
-                    charac.value = value
+                try:
+                    charac = self.__profile.find_object_by_handle(handle_uuid)
+                    if isinstance(charac, Characteristic):
+                        # Update value
+                        charac.value = value
+                except IndexError:
+                    self.error("Cannot find characteristic with UUID %s" % handle_uuid)
             else:
                 self.error('GATT profile has not been set.')
         elif isinstance(handle_uuid, UUID):

--- a/whad/scapy/layers/bluetooth.py
+++ b/whad/scapy/layers/bluetooth.py
@@ -21,10 +21,7 @@ class SM_Security_Request(Packet):
 
 bind_layers(SM_Hdr, SM_Security_Request, sm_command=0x0b)
 
-class BluetoothUserSocketFixed(BluetoothUserSocket):
-    pass
 
-'''
 class sockaddr_hci(ctypes.Structure):
     _fields_ = [
         ("sin_family", ctypes.c_ushort),
@@ -119,4 +116,4 @@ class BluetoothUserSocketFixed(SuperSocket):
             if self.ins and (WINDOWS or self.ins.fileno() != -1):
                 close(self.ins.fileno())
         close(self.hci_fd)
-'''
+


### PR DESCRIPTION
* Improved characteristic UUID write operation with better error handling
* Rolled back to a custom BluetoothHciSocket implementation since Scapy version 2.5.0rc3 does not correctly handle HCI socket termination