### PR TITLE
Improved wextract/wfilter and added user-defined transform primitive

### DIFF
--- a/whad/tools/user.py
+++ b/whad/tools/user.py
@@ -127,7 +127,7 @@ class UserTransformApp(CommandLineApp):
                 connector.format = hub.get(self.args.domain).format
 
                 if self.is_stdout_piped():
-                    unix_server = UnixConnector(UnixSocketServerDevice(parameters))
+                    unix_server = UnixConnector(UnixSocketServerDevice(parameters=parameters))
 
 
                     while not unix_server.device.opened:

--- a/whad/tools/user.py
+++ b/whad/tools/user.py
@@ -8,7 +8,8 @@ from scapy.themes import BrightTheme
 
 from whad.cli.app import CommandLineApp, run_app
 from whad.device.unix import UnixSocketServerDevice, UnixConnector
-from whad.device import Bridge, ProtocolHub
+from whad.device import Bridge
+from whad.hub import ProtocolHub
 
 logger = logging.getLogger(__name__)
 

--- a/whad/tools/user.py
+++ b/whad/tools/user.py
@@ -1,0 +1,163 @@
+"""User-defined transform tool
+"""
+import logging
+from time import sleep
+
+from scapy.config import conf
+from scapy.themes import BrightTheme
+
+from whad.cli.app import CommandLineApp, run_app
+from whad.device.unix import UnixSocketServerDevice, UnixConnector
+from whad.device import Bridge, ProtocolHub
+
+logger = logging.getLogger(__name__)
+
+class UserTransformPipe(Bridge):
+    """User-defined transform pipe
+    """
+    def __init__(self, input_connector, output_connector, on_rx_packet_cb, on_tx_packet_cb):
+        super().__init__(input_connector, output_connector)
+        self.on_rx_packet = on_rx_packet_cb
+        self.on_tx_packet = on_tx_packet_cb
+
+
+    def on_outbound(self, message):
+        """Process outbound messages.
+
+        Outbound packets are packets coming from our input connector,that need to be
+        forwarded as packets to the next tool.
+        """
+        if hasattr(message, "to_packet"):
+            pkt = message.to_packet()
+            pkt = self.on_rx_packet(pkt)
+            if pkt is not None:
+                msg = message.from_packet(pkt)
+                super().on_outbound(msg)
+        else:
+            logger.debug(
+                '[user-transform][input-pipe] forward default outbound message %s',
+                message
+            )
+            # Forward other messages
+            super().on_outbound(message)
+
+
+    def on_inbound(self, message):
+        """Process inbound messages.
+
+        Inbound packets are packets coming from our output connector,that need to be
+        forwarded as packets to the previous tool.
+        """
+        if hasattr(message, "to_packet"):
+            pkt = message.to_packet()
+            pkt = self.on_tx_packet(pkt)
+            if pkt is not None:
+                msg = message.from_packet(pkt)
+                super().on_inbound(msg)
+        else:
+            logger.debug(
+                '[user-transform][input-pipe] forward default inbound message %s',
+                message
+            )
+            # Forward other messages
+            super().on_inbound(message)
+
+
+class UserTransformApp(CommandLineApp):
+    """User-defined transform command-line application
+
+    This class defines a configurable transform application that calls user-defined
+    callbacks when packets flows in and out.
+    """
+
+    def __init__(self, inbound_cb = None, outbound_cb = None):
+        """Application uses an interface and has commands.
+        """
+        # Save callbacks
+        self.__inbound_cb = inbound_cb
+        self.__outbound_cb = outbound_cb
+
+        # Initialize user-defined transform app
+        super().__init__(
+            description='User transform application',
+            interface=True,
+            commands=False,
+            input=CommandLineApp.INPUT_WHAD,
+            output=CommandLineApp.OUTPUT_WHAD
+        )
+
+    def on_rx_packet(self, pkt):
+        """Process inbound packet
+        """
+        logger.debug("[user-transform][on_rx_packet] inbound packet received")
+        if self.__inbound_cb is not None:
+            pkt = self.__inbound_cb(pkt)
+        return pkt
+
+
+    def on_tx_packet(self, pkt):
+        """Process outbound packet
+        """
+        logger.debug("[user-transform][on_tx_packet] outbound packet received")
+        if self.__outbound_cb is not None:
+            pkt = self.__outbound_cb(pkt)
+        return pkt
+
+    def run(self):
+        """Application's main task
+        """
+        # Launch pre-run tasks
+        self.pre_run()
+
+        try:
+            if self.is_piped_interface():
+                interface = self.input_interface
+            else:
+                interface = self.interface
+
+            if interface is not None:
+                if not self.args.nocolor:
+                    conf.color_theme = BrightTheme()
+
+                parameters = self.args.__dict__
+                connector = UnixConnector(interface)
+
+                connector.domain = self.args.domain
+                hub = ProtocolHub(2)
+                connector.format = hub.get(self.args.domain).format
+
+                if self.is_stdout_piped():
+                    unix_server = UnixConnector(UnixSocketServerDevice(parameters))
+
+
+                    while not unix_server.device.opened:
+                        if unix_server.device.timedout:
+                            return
+                        else:
+                            sleep(0.1)
+                    # Create our packet bridge
+                    logger.debug("[user-transform] Starting our output pipe")
+                    _ = UserTransformPipe(
+                        connector,
+                        unix_server,
+                        self.on_rx_packet,
+                        self.on_tx_packet
+                    )
+
+                else:
+                    connector.on_packet = self.on_rx_packet
+
+                # Keep running while interface is active
+                while interface.opened:
+                    sleep(.1)
+            else:
+                exit(1)
+        except KeyboardInterrupt:
+            # Launch post-run tasks
+            self.post_run()
+
+def user_transform(inbound_cb, outbound_cb):
+    """User-defined transform application wrapper
+    """
+    app = UserTransformApp(inbound_cb, outbound_cb)
+    run_app(app)

--- a/whad/tools/wextract.py
+++ b/whad/tools/wextract.py
@@ -59,7 +59,7 @@ class WhadExtractApp(CommandLineApp):
         )
 
     def build_extractors(self) -> List[Tuple[str, callable]]:
-        """Build extracors based on provided arguments.
+        """Build extractors based on provided arguments.
 
         :rtype: list
         :return: list of extractors

--- a/whad/tools/wextract.py
+++ b/whad/tools/wextract.py
@@ -6,7 +6,6 @@ which can be used to access a device remotely.
 import sys
 import time
 import logging
-from typing import List, Tuple
 
 from scapy.packet import Packet
 from scapy.config import conf

--- a/whad/tools/wextract.py
+++ b/whad/tools/wextract.py
@@ -59,6 +59,8 @@ class WhadExtractApp(CommandLineApp):
         )
 
     def build_extractors(self):
+        """Build extracors based on provided arguments.
+        """
         extractor_template = "lambda p : %s"
         extractors = []
         for extractor in self.args.extractor:

--- a/whad/tools/wextract.py
+++ b/whad/tools/wextract.py
@@ -6,6 +6,7 @@ which can be used to access a device remotely.
 import sys
 import time
 import logging
+from typing import List, Tuple
 
 from scapy.packet import Packet
 from scapy.config import conf
@@ -57,8 +58,11 @@ class WhadExtractApp(CommandLineApp):
             help='load Scapy packet definitions from external Python file'
         )
 
-    def build_extractors(self):
+    def build_extractors(self) -> List[Tuple[str, callable]]:
         """Build extracors based on provided arguments.
+
+        :rtype: list
+        :return: list of extractors
         """
         extractor_template = "lambda p : %s"
         extractors = []

--- a/whad/tools/wfilter.py
+++ b/whad/tools/wfilter.py
@@ -138,11 +138,20 @@ class WhadFilterApp(CommandLineApp):
             help='forward packets not matched by the filter (dropped by default)'
         )
 
+        self.add_argument(
+            '-l',
+            '--load',
+            dest='load',
+            default=None,
+            nargs="+",
+            help='load Scapy packet definitions from external Python file'
+        )
+
         # Initialize our packet filter
         self.packet_filter = None
 
     def build_filter(self):
-        """Build filter based on provided arguments.
+        """Build filter from provided args.
         """
         if self.args.filter is None:
             self.args.filter = "True"


### PR DESCRIPTION
This PR fixes some bugs in `wextract` and `wfilter` and adds a new `--load` option to tell `wextract` or `wfilter` to load a specific Python module containing extra packet definitions based on Scapy syntax. This option has been added to allow users to load their own definition modules instead of modifying WHAD' source code for both filtering and extraction.

It also fixes a bug in parameters passed to a UnixSocketServer. 