### PR TITLE
Detect when a CLI app is redirected to /dev/null to suppress output (Linux only)

### DIFF
--- a/whad/cli/app.py
+++ b/whad/cli/app.py
@@ -595,6 +595,10 @@ class CommandLineApp(ArgumentParser):
                     return True
                 else:
                     logger.debug(f"[cli] stdout redirected to /dev/null, no unix socket needed")
+                    return False
+            else:
+                logger.debug("[cli] stdout is redirected and cannot determine if it leads to /dev/null or not (OS not Linux)")
+                return True
 
         return False
 


### PR DESCRIPTION
Redirecting stdout to /dev/null or another program standard input caused many CLI applications to spawn a Unix socket and await for a chained application to connect to it in order to start processing packets and/or events causing a deadlock.

WHAD's CLI base class has been improved to detect when an application's standard output is redirected into /dev/null to avoid this behaviour and simply suppress the application output as requested by the user.