### PR TITLE
Improved winject to better support raw hex packets, also improved IEEE 802.15.4 tools/examples documentation (#112)

### DIFF
--- a/doc/source/dot15d4/started.rst
+++ b/doc/source/dot15d4/started.rst
@@ -28,6 +28,9 @@ channel and sniff packets:
     # Set channel
     sniffer.channel = 11
 
+    # Start sniffing
+    sniffer.start()
+
     # Listen for packets
     for packet in sniffer.sniff():
         packet.show()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pyserial==3.5.0
 pycryptodomex==3.11.0
 pyusb==1.2.1
 cryptography==38.0.0
+packaging==24.0

--- a/tests/protocol/dot15d4/test_dot15d4_packets.py
+++ b/tests/protocol/dot15d4/test_dot15d4_packets.py
@@ -60,4 +60,4 @@ def test_raw_pdu_recv(factory):
     assert packet.metadata.timestamp == 1234
     assert packet.metadata.is_fcs_valid == True
     assert packet.metadata.lqi == 120
-    assert bytes(packet) == b"FOOBAR" + b'\x11\x22'
+    assert bytes(packet) == b"FOOBAR" + b'\x22\x11'

--- a/whad/cli/app.py
+++ b/whad/cli/app.py
@@ -290,6 +290,9 @@ class CommandLineApp(ArgumentParser):
     OUTPUT_STANDARD = 1
     OUTPUT_WHAD = 2
 
+    # Unique application instance
+    instance = None
+
     def __init__(self, description: str = None, commands: bool=True, interface: bool=True, input: int = INPUT_WHAD,
                  output: int = OUTPUT_WHAD, **kwargs):
         """Instanciate a CommandLineApp
@@ -302,6 +305,10 @@ class CommandLineApp(ArgumentParser):
         :param int input: specify the input type when application has its stdin piped
         :param int output: specify the output type when application has its stdout piped
         """
+        # Save application instance as a class property
+        if CommandLineApp.instance is None:
+            CommandLineApp.instance = self
+
         super().__init__(description=description, **kwargs)
 
         self.__interface = None
@@ -369,6 +376,13 @@ class CommandLineApp(ArgumentParser):
                 nargs='*',
                 help="command arguments"
             )
+
+    @staticmethod
+    def get_instance():
+        """Return unique application instance
+        """
+        return CommandLineApp.instance
+
 
     @property
     def interface(self):

--- a/whad/dot15d4/connector/__init__.py
+++ b/whad/dot15d4/connector/__init__.py
@@ -9,10 +9,12 @@ from scapy.compat import raw
 from scapy.config import conf
 from scapy.layers.dot15d4 import Dot15d4 as Dot15d4NoFCS
 from scapy.layers.dot15d4 import Dot15d4FCS
+
 from whad.scapy.layers.dot15d4tap import Dot15d4TAP_Hdr
 from whad.hub.dot15d4 import Dot15d4Metadata
 # Main whad imports
 from whad.hub.discovery import Domain, Capability
+from whad.cli.app import CommandLineApp
 from whad.device import WhadDeviceConnector
 from whad.helpers import message_filter, is_message_type
 from whad.exceptions import UnsupportedDomain, UnsupportedCapability
@@ -57,14 +59,21 @@ class Dot15d4(WhadDeviceConnector):
         # will be wrong if using a version prior to 1.1.0.
         if device.info.fw_url == "https://github.com/whad-team/butterfly":
             if Version(device.info.version_str) < Version("1.1.0"):
-                logger.warning((
-                    "[warning]------------------------------------------------------\n"
-                    "You are using a ButteRFly version prior to 1.1.0 that does not correctly compute FCS values,\n"
-                    "this will result in invalid FCS values in packets and PCAP files that may cause errors when\n"
-                    "used with other WHAD tools. Please consider upgrading firmware to the latest version \n"
-                    "(see https://github.com/whad-team/butterfly).\n"
-                    "---------------------------------------------------------------"
+                message = ((
+                    "You are using a ButteRFly version prior to 1.1.0 that does not correctly compute FCS values, "
+                    "this will result in invalid FCS values in packets and PCAP files that may cause errors when "
+                    "used with other WHAD tools. Please consider upgrading firmware to the latest version "
+                    "(see https://github.com/whad-team/butterfly). "
+                    "You can also use `winstall --flash butterfly` to reprogram your USB dongle."
                 ))
+
+                # Use application warning method if available
+                app = CommandLineApp.get_instance()
+                if app is not None:
+                    app.warning(message)
+                else:
+                    # If not available, use basic logging capabilities
+                    logger.warning(message)
 
         # Check if device supports 802.15.4
         if not self.device.has_domain(Domain.Dot15d4):

--- a/whad/hub/dot15d4/pdu.py
+++ b/whad/hub/dot15d4/pdu.py
@@ -56,10 +56,10 @@ class SendRawPdu(PbMessageWrapper):
         """Convert message to the corresponding scapy packet
         """
         try:
-            return Dot15d4FCS(self.pdu + bytes(pack('>H', self.fcs)))
+            return Dot15d4FCS(self.pdu + bytes(pack('<H', self.fcs)))
         except StructError:
             logger.debug("[hub::dot15d4] error parsing 802.15.4 frame (%s)",
-                         bytes(self.pdu).hex() + bytes(pack(">H", self.fcs)).hex())
+                         bytes(self.pdu).hex() + bytes(pack("<H", self.fcs)).hex())
             return None
 
     @staticmethod
@@ -170,7 +170,7 @@ class RawPduReceived(PbMessageWrapper):
         try:
             # Create packet
             #print('converting %s' % (self.pdu + bytes(pack(">H", self.fcs))).hex())
-            packet = Dot15d4FCS(bytes(self.pdu) + bytes(pack(">H", self.fcs)))
+            packet = Dot15d4FCS(bytes(self.pdu) + bytes(pack("<H", self.fcs)))
 
             # Set packet metadata
             packet.metadata = Dot15d4Metadata()
@@ -188,7 +188,7 @@ class RawPduReceived(PbMessageWrapper):
             return packet
         except StructError:
             logger.debug("[hub::dot15d4] error parsing 802.15.4 frame (%s)",
-                         bytes(self.pdu).hex() + bytes(pack(">H", self.fcs)).hex())
+                         bytes(self.pdu).hex() + bytes(pack("<H", self.fcs)).hex())
             return None
 
     @staticmethod


### PR DESCRIPTION
Following issue #112, we fixed multiple issues:

- `winject` code has been reworked to avoid arbitrary syntax errors when evaluating raw hex packets
- fixed a bug discovered while investigating wrong FCS values (now requires ButteRFly version 1.1.0 and displaying a warning if a previous version is used)