### PR TITLE
Improved scanner classes to support an optional timeout parameter (#118)

### DIFF
--- a/doc/source/dot15d4/started.rst
+++ b/doc/source/dot15d4/started.rst
@@ -31,8 +31,8 @@ channel and sniff packets:
     # Start sniffing
     sniffer.start()
 
-    # Listen for packets
-    for packet in sniffer.sniff():
+    # Listen for packets for 30 seconds
+    for packet in sniffer.sniff(timeout=30.0):
         packet.show()
 
 Sending packets

--- a/doc/source/unifying/started.rst
+++ b/doc/source/unifying/started.rst
@@ -33,8 +33,8 @@ The following snippet allows basic Logitech Unifying sniffing:
     # Configure scanning (loop on all channels)
     sniffer.scanning = True
 
-    # Sniff packets
-    for packet in sniffer.sniff():
+    # Sniff packets for 30 seconds
+    for packet in sniffer.sniff(timeout=30.0):
         packet.show()
 
 Any Logitech Unifying frame will be shown whatever the Logitech Unifying device is.

--- a/doc/source/zigbee/started.rst
+++ b/doc/source/zigbee/started.rst
@@ -25,8 +25,8 @@ ZigBee frames sent on channel 11:
     # Set channel
     sniffer.channel = 11
 
-    # Sniff packets
-    for packet in sniffer.sniff():
+    # Sniff packets for 30 seconds
+    for packet in sniffer.sniff(timeout=30.0):
         packet.show()
 
 Decrypting ZigBee packets on-the-fly while sniffing
@@ -54,7 +54,8 @@ To enable this feature, simply set the sniffer's ``decrypt`` property to True:
     sniffer.channel = 11
     sniffer.decrypt = True
 
-    # Sniff packets
+    # Sniff packets with no timeout
+    # (sniffing must be interrupted by the user)
     for packet in sniffer.sniff():
         packet.show()
 

--- a/examples/ble/ble_advertisements_sniffer.py
+++ b/examples/ble/ble_advertisements_sniffer.py
@@ -1,7 +1,8 @@
+import sys
+
 from whad.ble import Sniffer
 from whad.device import WhadDevice
 from whad.exceptions import WhadDeviceNotFound
-import sys
 
 if __name__ == '__main__':
     if len(sys.argv) >= 2:
@@ -20,7 +21,7 @@ if __name__ == '__main__':
 
             # Start the sniffer and iterate on received packets to display them
             sniffer.start()
-            for pkt in sniffer.sniff():
+            for pkt in sniffer.sniff(timeout=30.0):
                 print(repr(pkt))
 
         except (KeyboardInterrupt, SystemExit):

--- a/examples/zigbee/zigbee_sniffer.py
+++ b/examples/zigbee/zigbee_sniffer.py
@@ -26,10 +26,13 @@ if __name__ == '__main__':
 
             # Iterate over the received packets
             sniffer.start()
-            for i in sniffer.sniff():
+            for i in sniffer.sniff(timeout=30.0):
                 print(repr(i))
 
-
+            # Close monitor and device
+            monitor.detach()
+            monitor.close()
+            dev.close()
 
         except (KeyboardInterrupt, SystemExit):
             monitor.detach()

--- a/whad/phy/connector/sniffer.py
+++ b/whad/phy/connector/sniffer.py
@@ -1,4 +1,8 @@
 from queue import Queue
+from time import time
+from typing import Generator
+
+from scapy.packet import Packet
 
 from whad.exceptions import WhadDeviceDisconnected
 from whad.phy.connector import Phy
@@ -97,8 +101,15 @@ class Sniffer(Phy, EventsManager):
         actions = []
         return [action for action in actions if filter is None or isinstance(action, filter)]
 
-    def sniff(self):
+    def sniff(self, timeout: float = None) -> Generator[Packet, None, None]:
+        """Sniff packets out of thin air.
+
+        :param timeout: Specify the number of seconds after which sniffing will stop.
+                        Wait forever if set to `None`.
+        :type timeout: float
+        """
         try:
+            start = time()
             while True:
                 if self.support_raw_iq_stream():
                     message_type = RawPacketReceived
@@ -110,5 +121,10 @@ class Sniffer(Phy, EventsManager):
                     packet = message.to_packet()
                     self.monitor_packet_rx(packet)
                     yield packet
+                
+                # Check if timeout has been reached
+                if timeout is not None:
+                    if time() - start >= timeout:
+                        break
         except WhadDeviceDisconnected:
             return

--- a/whad/rf4ce/connector/sniffer.py
+++ b/whad/rf4ce/connector/sniffer.py
@@ -1,3 +1,9 @@
+import logging
+from typing import Generator
+from time import time
+
+from scapy.packet import Packet
+
 from whad.rf4ce.connector import RF4CE
 from whad.rf4ce.sniffing import SnifferConfiguration
 from whad.rf4ce.crypto import RF4CEDecryptor, RF4CEKeyDerivation
@@ -10,7 +16,7 @@ from whad.common.sniffing import EventsManager
 from whad.hub.dot15d4 import RawPduReceived, PduReceived
 from whad.hub.message import AbstractPacket
 from whad.exceptions import WhadDeviceDisconnected
-import logging
+
 
 logger = logging.getLogger(__name__)
 
@@ -128,7 +134,14 @@ class Sniffer(RF4CE, EventsManager):
                 pass
         return packet
 
-    def sniff(self):
+    def sniff(self, timeout: float = None) -> Generator[Packet, None, None]:
+        """Sniff RF4CE packets out of thin air.
+
+        :param timeout: Number of seconds after which sniffing will stop. Wait
+                        forever if set to `None`.
+        :type timeout: float
+        """
+        start = time()
         try:
             while True:
                 if self.support_raw_pdu():
@@ -143,5 +156,10 @@ class Sniffer(RF4CE, EventsManager):
                         packet = self.process_packet(packet)
                         self.monitor_packet_rx(packet)
                         yield packet
+
+                # Check if timeout has been reached
+                if timeout is not None:
+                    if time() - start >= timeout:
+                        break
         except WhadDeviceDisconnected:
             return


### PR DESCRIPTION
- Added a timeout parameter when it was missing in every domain's `Scanner` connector
- Updated documentation to reflect this timeout parameter
- Updated examples to use this timeout parameter