### PR TITLE
Fixed a regression in `wble-spawn` that caused the tool to crash

### DIFF
--- a/whad/ble/cli/ble_spawn.py
+++ b/whad/ble/cli/ble_spawn.py
@@ -43,6 +43,7 @@ class BleSpawnInputPipe(Bridge):
     def __init__(self, input_connector, output_connector):
         """Initialize our ble-spawn input pipe.
         """
+        self.__output_pending_packets = []
         logger.debug('[ble-spawn][input-pipe] Initialization')
         super().__init__(input_connector, output_connector)
 


### PR DESCRIPTION
When `wble-spawn` received packets to send to a connected Central device and no Central device was connected, it caused an exception because the `ouput_pending_packets` list has been removed during a recent code refactoring :man_facepalming:. Defining this member again in `__init__` solved the issue.