### PR TITLE
Added short version for `--output` option of `wble-proxy` (issue #117)

### DIFF
--- a/whad/ble/cli/ble_proxy.py
+++ b/whad/ble/cli/ble_proxy.py
@@ -207,6 +207,7 @@ class BleProxyApp(CommandLineDeviceSource):
         )
 
         self.add_argument(
+            "-o",
             "--output",
             dest="output",
             default=None,


### PR DESCRIPTION
Now `-o` is an alias of `--output` for `wble-proxy`.

Fixes issue #117.