### PR TITLE
Added debugging options to CLI tools documentation pages (issue #130)

### DIFF
--- a/doc/source/cli/ble/ble-central.rst
+++ b/doc/source/cli/ble/ble-central.rst
@@ -32,6 +32,8 @@ Command-line options
 * ``--file`` (``-f``): provides a script to execute
 * ``--no-color``: disables colors in output
 
+.. include:: ../generic/debug-options.rst
+
 Supported commands
 ------------------
 

--- a/doc/source/cli/ble/ble-connect.rst
+++ b/doc/source/cli/ble/ble-connect.rst
@@ -16,14 +16,15 @@ Usage
 Command-line options
 --------------------
 
-**ble-proxy** supports the following options:
+**wble-connect** supports the following options:
 
 * ``--interface`` (``-i``): specifies the WHAD interface to use to connect to the target device
 * ``--no-color``: disables colors in output
 * ``--spoof-public``: if supported, sets WHAD adapter's BD address to the specified public address
 * ``--spoof-random``: if supported, sets WHAD adapter's BD address to the specified random address
-* ``--random`` (``-r``): target device BD address is random (default: public)
+* ``--random`` (``-r``): if set, consider the target device BD address is random (default: public)
 
+.. include:: ../generic/debug-options.rst
 
 Example usage
 -------------

--- a/doc/source/cli/ble/ble-periph.rst
+++ b/doc/source/cli/ble/ble-periph.rst
@@ -30,6 +30,7 @@ Command-line options
 * ``--file`` (``-f``): provides a script to execute
 * ``--no-color``: disables colors in output
 
+.. include:: ../generic/debug-options.rst
 
 Quick tutorial
 --------------

--- a/doc/source/cli/ble/ble-proxy.rst
+++ b/doc/source/cli/ble/ble-proxy.rst
@@ -34,6 +34,7 @@ Command-line options
 * ``--link-layer``: enable link-layer mode (default mode is GATT)
 * ``--output`` (``-o``): specifies a target PCAP file in which all exchanged packets will be saved
 
+.. include:: ../generic/debug-options.rst
 
 Create a GATT proxy and monitor traffic
 ---------------------------------------

--- a/doc/source/cli/ble/ble-spawn.rst
+++ b/doc/source/cli/ble/ble-spawn.rst
@@ -10,12 +10,22 @@ Usage
 
 .. code-block:: text
 
-    wble-spawn -i <INTERFACE> -p [PROFILE]
+    wble-spawn [OPTIONS]
 
 A compatible WHAD *interface* and the path to a JSON *profile* are required to
 populate the BLE device with the corresponding services and characteristics. It
 will also allow `wble-spawn` to use the same advertising data, in order to make
 the emulated device appear the same way the original does.
+
+Command-line options
+--------------------
+
+**wble-spawn** supports the following options:
+
+* ``--interface`` (``-i``): specifies the WHAD interface to use to connect to the target device
+* ``--profile`` (``-p``): specifies the GATT profile file (JSON) to use
+
+.. include:: ../generic/debug-options.rst
 
 Example
 -------

--- a/doc/source/cli/generic/debug-options.rst
+++ b/doc/source/cli/generic/debug-options.rst
@@ -1,0 +1,4 @@
+It also supports the following debugging options:
+
+* ``--log``: if set, specifies the level of logging (must be one of the following, from the less verbose to the more verbose level): `error`, `warn`, `info`, `debug`
+* ``--log-file FILE``: if set, logging will output messages to the specified file ``FILE`` instead of using standard output

--- a/doc/source/cli/generic/wanalyze.rst
+++ b/doc/source/cli/generic/wanalyze.rst
@@ -48,6 +48,8 @@ Command-line options
 * ``--raw`` (``-r``): dump output directly to stdout buffer (e.g., to process raw bytes)
 * ``--list`` (``-l``): display a list of available analyzers
 
+.. include:: debug-options.rst
+
 Displaying the available analyzers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/doc/source/cli/generic/wdump.rst
+++ b/doc/source/cli/generic/wdump.rst
@@ -20,6 +20,8 @@ Command-line options
 * ``--force`` (``-f``): force PCAP file overwrite, if destination file already exists
 * ``--append`` (``-a``): append packets to an existing file, create new file if it does not exist
 
+.. include:: debug-options.rst
+
 Saving filtered packets into a PCAP file
 ----------------------------------------
 

--- a/doc/source/cli/generic/wextract.rst
+++ b/doc/source/cli/generic/wextract.rst
@@ -23,6 +23,7 @@ Command-line options
 * ``--exceptions`` (``-x``): enable verbose output on exceptions for debugging 
 * ``--load`` (``-l``): load specified Python module containing extra Scapy layers definitions
 
+.. include:: debug-options.rst
 
 Writing extractors
 ^^^^^^^^^^^^^^^^^^

--- a/doc/source/cli/generic/wfilter.rst
+++ b/doc/source/cli/generic/wfilter.rst
@@ -27,6 +27,8 @@ Command-line options
 * ``--forward`` (``-f``): forward packets that do not match the specified filter (dropped by default)
 * ``--load`` (``-l``): load specified Python module containing extra Scapy layers definitions
 
+.. include:: debug-options.rst
+
 Specifying a filter
 ^^^^^^^^^^^^^^^^^^^
 

--- a/doc/source/cli/generic/winject.rst
+++ b/doc/source/cli/generic/winject.rst
@@ -31,6 +31,8 @@ Command-line options
 * ``--repeat`` (``-r``): repeat the transmission of packets
 * ``--delay DELAY`` (``-d DELAY``): delay between the transmission of two consecutive packets
 
+.. include:: debug-options.rst
+
 Specific PHY options
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/doc/source/cli/generic/wplay.rst
+++ b/doc/source/cli/generic/wplay.rst
@@ -27,6 +27,8 @@ Command-line options
 * ``--wireshark`` (``-w``): spawns a wireshark instance that will monitor packets in real-time
 * ``--flush``: enable wireshark monitoring
 
+.. include:: debug-options.rst
+
 How to replay a PCAP file with ``wplay``
 ----------------------------------------
 

--- a/doc/source/cli/generic/wserver.rst
+++ b/doc/source/cli/generic/wserver.rst
@@ -26,6 +26,8 @@ Command-line options
 * ``--address`` (``-a``): specify an IP address to listen on (default: `127.0.0.1` or `::1`)
 * ``--port`` (``-p``): specify the port to use (default: `12345`)
 
+.. include:: debug-options.rst
+
 Exposing a WHAD device over TCP
 -------------------------------
 

--- a/doc/source/cli/generic/wshark.rst
+++ b/doc/source/cli/generic/wshark.rst
@@ -16,6 +16,8 @@ Usage
 
     ... | wshark | ...
 
+.. include:: ../generic/debug-options.rst
+
 Simple example
 --------------
 

--- a/doc/source/cli/generic/wsniff.rst
+++ b/doc/source/cli/generic/wsniff.rst
@@ -40,6 +40,8 @@ with all their consecutive layers and fields as produced by *Scapy* packet's ``s
 ``repr`` format will show a packet's Python object representation by calling its ``__repr__()``
 method.
 
+.. include:: debug-options.rst
+
 Capture raw demodulated data
 ----------------------------
 

--- a/doc/source/cli/unifying/wuni-keyboard.rst
+++ b/doc/source/cli/unifying/wuni-keyboard.rst
@@ -29,6 +29,7 @@ Command-line options
 * ``--locale`` (``-l``): specify a keyboard disposition (default: *us*)
 * ``--key`` (``-k``): encryption key (in hex) to use for payload injection, enables encryption if set
 
+.. include:: ../generic/debug-options.rst
 
 Logging keyboard keypresses
 ---------------------------

--- a/doc/source/cli/unifying/wuni-mouse.rst
+++ b/doc/source/cli/unifying/wuni-mouse.rst
@@ -26,6 +26,7 @@ Command-line options
 * ``--address`` (``-a``): specify the target wireless mouse address
 * ``--duplicate`` (``-d``): enable mouse duplication feature
 
+.. include:: ../generic/debug-options.rst
 
 Logging mouse moves and button presses
 --------------------------------------

--- a/doc/source/cli/unifying/wuni-scan.rst
+++ b/doc/source/cli/unifying/wuni-scan.rst
@@ -18,6 +18,8 @@ A compatible WHAD *interface* is required to listen to packets transmitted by a
 Logitech Unifying device. Channel (*CHANNEL*) and device address (*ADDRESS*) are
 optional and will allow `wuni-scan` to better track a device and not miss a packet.
 
+.. include:: ../generic/debug-options.rst
+
 Searching for Logitech Unifying devices on any channel
 ------------------------------------------------------
 

--- a/doc/source/cli/zigbee/zb-enddevice.rst
+++ b/doc/source/cli/zigbee/zb-enddevice.rst
@@ -28,6 +28,8 @@ Command-line options
 * ``--network-panid`` (``-t``): specifies a target extended ZigBee network PAN ID (64 bits)
 * ``--file`` (``-f``): provides a script to execute
 
+.. include:: ../generic/debug-options.rst
+
 Discover ZigBee networks
 ------------------------
 


### PR DESCRIPTION
- Added a dedicated RST file in documentation specifying the debugging options (`--log` and `--log-file`)
- Modified CLI tools documentation pages to include this file

Note: could be interesting to move all generic options into this file, rename it to `genoptions.rst` and refactor all the tools doc pages.