### PR TITLE
Improve HCI adapters numbering to match system interfaces (issue #137)

### DIFF
--- a/whad/device/device.py
+++ b/whad/device/device.py
@@ -245,18 +245,29 @@ class WhadDevice:
                 except ValueError:
                     index = None
 
+            # Retrieve the list of available devices
+            # (could be a list or a dict)
             available_devices = cls.list()
+
             # If the list of device is built statically, check before instantiation
             if available_devices is not None:
                 if index is not None:
                     try:
+                        # Try to retrieve a device based on the provided index
                         return available_devices[index]
+                    except KeyError as exc:
+                        raise WhadDeviceNotFound from exc
                     except IndexError as exc:
                         raise WhadDeviceNotFound from exc
                 elif identifier is not None:
-                    for dev in available_devices:
-                        if dev.identifier == identifier:
-                            return dev
+                    if isinstance(available_devices, list):
+                        for dev in available_devices:
+                            if dev.identifier == identifier:
+                                return dev
+                    elif isinstance(available_devices, dict):
+                        for dev_id, dev in available_devices.items():
+                            if dev.identifier == identifier:
+                                return dev
                     raise WhadDeviceNotFound
                 else:
                     raise WhadDeviceNotFound

--- a/whad/device/virtual/hci/__init__.py
+++ b/whad/device/virtual/hci/__init__.py
@@ -95,7 +95,7 @@ class HCIDevice(VirtualDevice):
         return available_devices
 
     def __init__(self, index):
-        super().__init__()
+        super().__init__(index=index)
         self.__converter = HCIConverter(self)
         self.__index = index
         self.__socket = None

--- a/whad/device/virtual/hci/__init__.py
+++ b/whad/device/virtual/hci/__init__.py
@@ -86,10 +86,11 @@ class HCIDevice(VirtualDevice):
         '''
         Returns a list of available HCI devices.
         '''
-        available_devices = []
+        available_devices = {}
         devices_ids = HCIConfig.list()
         for device_id in devices_ids:
-            available_devices.append(HCIDevice(index=device_id))
+            #available_devices.append(HCIDevice(index=device_id))
+            available_devices[device_id] = HCIDevice(index=device_id)
 
         return available_devices
 


### PR DESCRIPTION
- Device classes can now return a list or a dict of devices through their `list()` method
- Whadup/wup has been modified to accept the new version of `list()`
- Update `WhadDevice` to allow a device index value to be set instead of being automatically assigned