### PR TITLE
Fixed wrong WHAD message processing and BLE scanning (fixes #119 and #139)

### DIFF
--- a/whad/ble/cli/ble_proxy.py
+++ b/whad/ble/cli/ble_proxy.py
@@ -258,7 +258,11 @@ class BleProxyApp(CommandLineDeviceSource):
             # Device search timeout reached, show warning and stop proxy
             if time() - scan_start_ts > self.args.timeout:
                 self.warning("Target device not found, connection timeout exceeded.")
+                scanner.stop()
                 return
+
+        # Stop scanning
+        scanner.stop()
 
         if adv_data is not None and scan_rsp is not None:
             if not self.args.linklayer:

--- a/whad/ble/connector/scanner.py
+++ b/whad/ble/connector/scanner.py
@@ -74,6 +74,14 @@ class Scanner(BLE):
         self.__db.reset()
         super().start()
 
+    def stop(self):
+        """Stop scanning.
+
+        Stop scanning for devices, disable scan mode if used.
+        """
+        if self.can_scan():
+            self.enable_scan_mode(False)
+        super().stop()
 
     def discover_devices(self, minimal_rssi = None, filter_address = None,
                          timeout: float = None) -> Iterator[AdvertisingDevice]:
@@ -101,7 +109,6 @@ class Scanner(BLE):
 
             if (timeout is not None) and (time() - start_time > timeout):
                 break
-
 
     def sniff(self) -> Iterator[Packet]:
         """

--- a/whad/device/device.py
+++ b/whad/device/device.py
@@ -808,6 +808,11 @@ class WhadDevice:
         #if self.__closing:
         #    return
 
+        # If no connector set, we cannot process messages, we keep them in
+        # memory instead.
+        if self.__connector is None:
+            return False
+
         try:
             message = self.__messages.get(block=True, timeout=timeout)
             if message is not None:


### PR DESCRIPTION
* Bad WHAD message processing caused a lot of errors when used in a virtual environment (especially with VMWare Workstation)
* HCI interfaces scanning was not correctly disabled and caused a lot of message collisions