### PR TITLE
Fixed IEEE 802.15.4 sniffer connector and updated Zigbee sniffing example code (fixes #161)

### DIFF
--- a/doc/source/dot15d4/started.rst
+++ b/doc/source/dot15d4/started.rst
@@ -44,7 +44,7 @@ Sending IEEE 802.15.4 packets is as easy as it sounds, simply use the
 .. code-block:: python
 
     from whad.device import WhadDevice
-    from whad.dot15d4 import Sniffer
+    from whad.dot15d4 import Dot15d4
 
     # Create a compatible device instance
     device = WhadDevice.create("uart0")

--- a/doc/source/zigbee/started.rst
+++ b/doc/source/zigbee/started.rst
@@ -25,6 +25,9 @@ ZigBee frames sent on channel 11:
     # Set channel
     sniffer.channel = 11
 
+    # Start sniffer
+    sniffer.start()
+
     # Sniff packets for 30 seconds
     for packet in sniffer.sniff(timeout=30.0):
         packet.show()


### PR DESCRIPTION
- Added timeout support for IEEE 802.15.4 sniffer connector
- Updated Zigbee's example code to include a missing statement (`sniffer.start()` required before calling `sniff()`)