### PR TITLE
Fixed BD address spoofing in HCI adapter (#169)

### DIFF
--- a/whad/device/virtual/hci/__init__.py
+++ b/whad/device/virtual/hci/__init__.py
@@ -474,7 +474,8 @@ class HCIDevice(VirtualDevice):
         logger.debug("raising WhadDeviceNotReady exception")
         raise WhadDeviceNotReady()
 
-    def _set_bd_address(self, bd_address="11:22:33:44:55:66", bd_address_type=AddressType.PUBLIC):
+    def _set_bd_address(self, bd_address: bytes = b"\x00\x11\x22\x33\x44\x55",
+                        bd_address_type: int = AddressType.PUBLIC) -> bool:
         """
         Modify the BD address (if supported by the HCI device).
         """
@@ -524,7 +525,7 @@ class HCIDevice(VirtualDevice):
                         b'Integrated System Solution Corp.' : HCI_Cmd_Ericsson_Write_BD_Address,
                         b'ST Microelectronics' : HCI_Cmd_ST_Write_BD_Address
                     }
-                    command = bd_address_mod_map[self._manufacturer]
+                    command = bd_address_mod_map[self._manufacturer](addr=bd_address)
                     self._write_command(command, wait_response=False)
                     self._reset()
 


### PR DESCRIPTION
HCI adapter implements BD address spoofing depending on the hardware but had a typo in the way it crafted the custom HCI vendor command (see issue #169), thus causing an error and breaking multiple tools. This PR fixes this.