### PR TITLE
Fixed pyproject.toml (#134)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ authors = [
 ]
 readme="README.md"
 
-license = { text="Apache" }
+license = "MIT"
 requires-python = ">=3.7, <4"
 description = "Wireless protocols hacking framework"
 classifiers = [
@@ -31,8 +31,6 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Operating System :: POSIX :: Linux",
-  "License :: OSI Approved :: MIT License"
-
 ]
 dependencies = [
     "protobuf==3.20.*",
@@ -95,7 +93,7 @@ whad = [
   "resources/pcaps/*.pcap",
   "resources/rules/*.rules",
   "resources/wireshark/*.lua",
-  "data/clues/CLUES_data.json",
+  "resources/clues/CLUES_data.json",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ authors = [
 ]
 readme="README.md"
 
-license = "MIT"
+license = {text = "MIT License"}
 requires-python = ">=3.7, <4"
 description = "Wireless protocols hacking framework"
 classifiers = [

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,6 @@ description = python library allowing to interact with offensive security tools 
 author = 'Damien Cauquil, Romain Cayre'
 author_email = 'dcauquil@quarkslab.com, rcayre@laas.fr'
 license = MIT
-license_files = LICENSE
 platforms = unix, linux
 classifiers =
   Programming Language :: Python :: 3

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,8 +13,7 @@ classifiers =
   Programming Language :: Python :: 3.8
   Programming Language :: Python :: 3.9
   Programming Language :: Python :: 3.10
-  Operating System :: POSIX :: Linux,
-  License :: OSI Approved :: MIT License
+  Operating System :: POSIX :: Linux
 
 [options]
 packages =


### PR DESCRIPTION
- Fixed project setup files to correctly include DarkMentorLLC's CLUES_data.json file (as mentionned in #134)
- Remove license classifiers as it is now deprecated