### PR TITLE
fix typo: instanciate -> instantiate

### DIFF
--- a/doc/source/ble/started.rst
+++ b/doc/source/ble/started.rst
@@ -4,7 +4,7 @@ Getting started
 Scan available devices
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Use the :class:`whad.ble.connector.scanner.Scanner` class to instanciate
+Use the :class:`whad.ble.connector.scanner.Scanner` class to instantiate
 a BLE device scanner and detect all the available devices.
 
 .. code-block:: python
@@ -149,12 +149,12 @@ the device services and characteristics:
             ),
         )
 
-Once this profile defined, instanciate a :class:`whad.ble.connector.Peripheral` object
+Once this profile defined, instantiate a :class:`whad.ble.connector.Peripheral` object
 using this profile:
 
 .. code-block:: python
 
-    # Instanciate our peripheral
+    # Instantiate our peripheral
     my_profile = MyPeripheral()
 
     # Create a periphal device based on this profile

--- a/doc/source/esb/started.rst
+++ b/doc/source/esb/started.rst
@@ -9,7 +9,7 @@ more details.
 Scan available devices
 ----------------------
 
-Use the :class:`whad.esb.connector.scanner.Scanner` class to instanciate
+Use the :class:`whad.esb.connector.scanner.Scanner` class to instantiate
 a BLE device scanner and detect all the available devices.
 
 .. code-block:: python

--- a/tests/domain/ble/test_l2cap.py
+++ b/tests/domain/ble/test_l2cap.py
@@ -28,7 +28,7 @@ class LinkLayerMock(Sandbox):
     def __init__(self, parent=None, layer_name=None, options={}):
         super().__init__(parent=parent, layer_name=layer_name, options=options)
         
-        # Instanciate a L2CAP layer and configure target
+        # Instantiate a L2CAP layer and configure target
         self.__l2cap = self.instantiate(L2CAPLayer)
         self.target = self.__l2cap.name
 

--- a/whad/ble/cli/peripheral/shell.py
+++ b/whad/ble/cli/peripheral/shell.py
@@ -1166,7 +1166,7 @@ class BlePeriphShell(InteractiveShell):
         self.update_prompt()
 
         try:
-            # Instanciate our Peripheral
+            # Instantiate our Peripheral
             self.__connector = Peripheral(
                 self.__interface,
                 profile=self.__profile,
@@ -1179,7 +1179,7 @@ class BlePeriphShell(InteractiveShell):
         except AdvDataFieldListOverflow:
             self.error("Advertising data is too big to fit in advertisement !")
         
-        # Instanciate our Peripheral
+        # Instantiate our Peripheral
         # self.__connector = Peripheral(
         #    self.__interface,
         #    profile=self.__profile,

--- a/whad/ble/profile/__init__.py
+++ b/whad/ble/profile/__init__.py
@@ -167,7 +167,7 @@ class CharacteristicDescriptor:
     """
 
     def __init__(self, bleclass=None):
-        """Instanciate a characteristic descriptor model
+        """Instantiate a characteristic descriptor model
 
         :param str name: attribute name to access this descriptor
         :param class bleclass: BLE descriptor class to use when instanciating the model
@@ -497,7 +497,7 @@ class GenericProfile:
     """
 
     def __init__(self, start_handle=0, from_json=None):
-        """Parse the device model, instanciate all the services, characteristics
+        """Parse the device model, instantiate all the services, characteristics
         and descriptors, compute all handle values and registers everything
         inside this instance for further use.
 
@@ -587,7 +587,7 @@ class GenericProfile:
                         service.name = prop
                         services.append(service)
 
-            # Instanciate each service, and for each of them the corresponding
+            # Instantiate each service, and for each of them the corresponding
             # characteristics
             for service in services:
                 if isinstance(service, PrimaryService):

--- a/whad/ble/profile/advdata.py
+++ b/whad/ble/profile/advdata.py
@@ -97,7 +97,7 @@ class AdvUuid16List(AdvDataField):
     def from_bytes(clazz, ad_record):
         """Deserialize a record containing a list of 16-bit UUIDs.
 
-        :param class clazz: Class that will be instanciated (must inherit from AdvUuid16List)
+        :param class clazz: Class that will be instantiated (must inherit from AdvUuid16List)
         :param bytes ad_record: AD record to deserialize.
         """
         nb_uuids = int(len(ad_record)/2)
@@ -145,7 +145,7 @@ class AdvUuid128List(AdvDataField):
     def from_bytes(clazz, ad_record):
         """Deserialize a record containing a list of 128-bit UUIDs.
 
-        :param class clazz: Class that will be instanciated (must inherit from AdvUuid128List)
+        :param class clazz: Class that will be instantiated (must inherit from AdvUuid128List)
         :param bytes ad_record: AD record to deserialize.
         """
         nb_uuids = int(len(ad_record)/16)

--- a/whad/ble/profile/attribute.py
+++ b/whad/ble/profile/attribute.py
@@ -603,7 +603,7 @@ class Attribute:
     """GATT Attribute model
     """
     def __init__(self, uuid, handle=None, value=0):
-        """Instanciate a GATT Attribute
+        """Instantiate a GATT Attribute
         """
         self.__uuid = uuid
         self.__handle = handle

--- a/whad/ble/profile/characteristic.py
+++ b/whad/ble/profile/characteristic.py
@@ -58,7 +58,7 @@ class ClientCharacteristicConfig(CharacteristicDescriptor):
     """
 
     def __init__(self, characteristic, handle=0, notify=False, indicate=False):
-        """Instanciate a Client Characteristic Configuration Descriptor
+        """Instantiate a Client Characteristic Configuration Descriptor
 
         :param bool notify: Set to True to get the corresponding characteristic notified on change
         :param bool indicate: Set to True to get the corresponding characteristic
@@ -89,7 +89,7 @@ class ReportReferenceDescriptor(CharacteristicDescriptor):
     """
 
     def __init__(self, characteristic, handle=None):
-        """Instanciate a Report Reference Descriptor
+        """Instantiate a Report Reference Descriptor
 
         :param bool notify: Set to True to get the corresponding characteristic notified on change
         :param bool indicate: Set to True to get the corresponding characteristic
@@ -107,7 +107,7 @@ class CharacteristicUserDescriptionDescriptor(CharacteristicDescriptor):
     a textual description of the related characteristic.
     """
     def __init__(self, characteristic, handle=None, description=''):
-        """Instanciate a Characteristic User Description descriptor
+        """Instantiate a Characteristic User Description descriptor
 
         :param description: Set characteristic text description
         """
@@ -146,7 +146,7 @@ class Characteristic(Attribute):
 
     def __init__(self, uuid, handle=0, end_handle=0, value=b'', properties=BleAttProperties.DEFAULT,
                  security=None):
-        """Instanciate a BLE characteristic object
+        """Instantiate a BLE characteristic object
 
         :param uuid: 16-bit or 128-bit UUID
         :param int handle: Handle value

--- a/whad/ble/stack/smp/__init__.py
+++ b/whad/ble/stack/smp/__init__.py
@@ -301,7 +301,7 @@ class SM_Peer(object):
 
 
     def __init__(self, address):
-        """Instanciate a SM_Peer.
+        """Instantiate a SM_Peer.
 
         By default, peers are configured to only accept Legacy JustWorks pairing.
         """

--- a/whad/ble/tools/proxy.py
+++ b/whad/ble/tools/proxy.py
@@ -77,7 +77,7 @@ class LowLevelPeripheral(Peripheral):
     """
 
     def __init__(self, proxy, device, adv_data, scan_data, bd_address=None, public=True):
-        """Instanciate a LowLevelPeripheral instance
+        """Instantiate a LowLevelPeripheral instance
 
         :param LinkLayerProxy proxy: Reference to the link-layer proxy that will receive events
         :param WhadDevice device: A :class:`whad.device.WhadDevice` object to use
@@ -246,7 +246,7 @@ class LowLevelCentral(Central):
     """
 
     def __init__(self, proxy, device, connection_data=None):
-        """Instanciate a LowLevelCentral object
+        """Instantiate a LowLevelCentral object
 
         :param WhadDevice device: Underlying WHAD device to use.
         """

--- a/whad/cli/app.py
+++ b/whad/cli/app.py
@@ -292,7 +292,7 @@ class CommandLineApp(ArgumentParser):
     def __init__(self, description: str = None, commands: bool=True, interface: bool=True,
                  input: int = INPUT_WHAD,
                  output: int = OUTPUT_WHAD, **kwargs):
-        """Instanciate a CommandLineApp
+        """Instantiate a CommandLineApp
 
         :param str program_name: program (app) name
         :param str usage: usage string

--- a/whad/common/monitors/pcap.py
+++ b/whad/common/monitors/pcap.py
@@ -68,7 +68,7 @@ class PcapWriterMonitor(WhadMonitor):
                     remove(self._pcap_file)
                     existing_pcap_file = False
 
-        # Instanciate the PCAP Writer with the appropriate parameters
+        # Instantiate the PCAP Writer with the appropriate parameters
         self._writer_lock.acquire()
         self._writer = PcapWriter(
                                     self._pcap_file,

--- a/whad/common/stack/layer.py
+++ b/whad/common/stack/layer.py
@@ -381,7 +381,7 @@ class Layer(object):
     def populate(self, options={}):
         """Sub-layers instanciation.
 
-        We instanciate each layer and register these instances into our object.
+        We instantiate each layer and register these instances into our object.
         """
         self.__options = options
 
@@ -636,7 +636,7 @@ class Layer(object):
     def configure(self, options):
         """Configure callback.
 
-        Override this method to configure the layer when the stack is instanciated.
+        Override this method to configure the layer when the stack is instantiated.
         """
         pass
 
@@ -730,7 +730,7 @@ class Layer(object):
 
 class ContextualLayer(Layer):
     """This layer is not automatically loaded when the stack model is created
-    and must be instanciated specifically by another layer.
+    and must be instantiated specifically by another layer.
     """
 
     @classmethod

--- a/whad/hub/__init__.py
+++ b/whad/hub/__init__.py
@@ -27,7 +27,7 @@ class ProtocolHub(Registry):
     VERSIONS = {}
 
     def __init__(self, proto_version: int):
-        """Instanciate a WHAD protocol hub for a specific version.
+        """Instantiate a WHAD protocol hub for a specific version.
         """
         self.__version = proto_version
 

--- a/whad/lorawan/stack/llm.py
+++ b/whad/lorawan/stack/llm.py
@@ -183,7 +183,7 @@ class LWGwLinkLayer(Layer):
                 dev_appskey = derive_appskey(self.appkey, join_nonce, 0x13, join_req.dev_nonce)
                 dev_nwkskey = derive_nwkskey(self.appkey, join_nonce, 0x13, join_req.dev_nonce)
 
-                # Instanciate a node for our connection
+                # Instantiate a node for our connection
                 conn_mac = self.instantiate(LWMacLayer)
                 conn_mac.set_devaddr(dev_addr)
 
@@ -256,7 +256,7 @@ class LWGwLinkLayer(Layer):
             dev_addr, dev_eui
         ))
 
-        # Instanciate a node for our connection
+        # Instantiate a node for our connection
         conn_mac = self.instantiate(LWMacLayer)
         conn_mac.set_devaddr(dev_addr)
         logger.debug('created a LWMACLayer instance for device: %s' % conn_mac.name)


### PR DESCRIPTION
It's English's fault, because it *would* make sense for it to be instanciate for creating an instance...but unfortunately it's not...