### PR TITLE
Added name property to PeripheralCharacteristic and PeripheralService classes (Fixes #181)

### DIFF
--- a/whad/ble/profile/device.py
+++ b/whad/ble/profile/device.py
@@ -344,19 +344,19 @@ class PeripheralCharacteristic:
                                   indication/notification event
         :return bool: True if subscription has successfully been performed, False otherwise.
         """
+        # wrap our callback to provide more details about the concerned
+        # characteristic
+        def wrapped_cb(_, value, indication=False):
+            callback(
+                self,
+                value,
+                indication=indication
+            )
+
         if notification:
             # Look for CCCD
             desc = self.get_descriptor(UUID(0x2902))
             if desc is not None:
-                # wrap our callback to provide more details about the concerned
-                # characteristic
-                def wrapped_cb(handle, value, indication=False):
-                    callback(
-                        self,
-                        value,
-                        indication=indication
-                    )
-
                 # Register our callback
                 if callback is not None:
                     self.__gatt.register_notification_callback(
@@ -381,7 +381,7 @@ class PeripheralCharacteristic:
                 if callback is not None:
                     self.__gatt.register_notification_callback(
                         self.__characteristic.value_handle,
-                        callback
+                        wrapped_cb
                     )
 
                 # Enable indication

--- a/whad/ble/profile/device.py
+++ b/whad/ble/profile/device.py
@@ -166,6 +166,12 @@ class PeripheralCharacteristic:
         self.__gatt = gatt
 
     @property
+    def name(self) -> str:
+        """Characteristic name.
+        """
+        return self.__characteristic.name
+
+    @property
     def value(self) -> bytes:
         """Transparent characteristic read.
 
@@ -424,6 +430,12 @@ class PeripheralService:
     def __init__(self, service, gatt):
         self.__service = service
         self.__gatt = gatt
+
+    @property
+    def name(self) -> str:
+        """Service name.
+        """
+        return self.__service.name
 
     @property
     def handle(self):


### PR DESCRIPTION
`PeripheralCharacteristic` and `PeripheralService` classes are used to represent a GATT characteristic or a service discovered on a remote Peripheral, but they were missing a `name` property while their counterparts used in our GATT local model do provide this property.

The `name` property is used to provide a readable characteristic's or service's name based on its UUID, including a textual description if available (defined either in the [Bluetooth Assigned Numbers document](https://www.bluetooth.com/specifications/assigned-numbers/) or [DarkMentorLLC's CLUES database](https://github.com/darkmentorllc/CLUES_Schema).