### PR TITLE
Documentation updated to reflect recent changes in BLE packet injection example (now using synchronous mode), fixes #183

### DIFF
--- a/doc/source/api/device.rst
+++ b/doc/source/api/device.rst
@@ -1,0 +1,5 @@
+Device and connector
+====================
+
+.. automodule:: whad.device
+    :members: WhadDevice, VirtualDevice, WhadDeviceConnector, WhadDeviceInfo, Bridge

--- a/doc/source/api/monitors.rst
+++ b/doc/source/api/monitors.rst
@@ -1,0 +1,5 @@
+Packet monitors
+===============
+
+.. automodule:: whad.common.monitors
+    :members: PcapWriterMonitor, WiresharkMonitor

--- a/doc/source/ble/started.rst
+++ b/doc/source/ble/started.rst
@@ -198,8 +198,8 @@ and :py:class:`whad.ble.connector.Central` connector provides a nifty way to do 
     # Make sure connection has succeeded
     if device is not None:
         
-        # Disable auto mode
-        central.auto(False)
+        # Enable synchronous mode: we must process any incoming BLE packet.
+        central.enable_synchronous(True)
 
         # Send a LL_VERSION_PDU
         central.send_pdu(BTLE_DATA()/BTLE_CTRL()/LL_VERSION_IND(
@@ -208,9 +208,9 @@ and :py:class:`whad.ble.connector.Central` connector provides a nifty way to do 
             subversion = 0x0001
         ))
 
-        # Wait for a PDU
+        # Wait for a packet
         while central.is_connected():
-            pdu = central.wait_pdu()
+            pdu = central.wait_packet()
             if pdu.haslayer(LL_VERSION_IND):
                 pdu[LL_VERSION_IND].show()
                 break
@@ -221,22 +221,24 @@ and :py:class:`whad.ble.connector.Central` connector provides a nifty way to do 
 The above example connects to a target device, sends an `LL_VERSION_IND`
 PDU and waits for an `LL_VERSION_IND` PDU from the remote device.
 
-Normally, when a :class:`whad.ble.connector.Central` or :class:`whad.ble.connector.Peripheral`
-connector is used it relies on a protocol stack to handle outgoing and ingoing
-PDUs. By doing so, there is no way to get access to the received PDUs and avoid
-them to be forwarded to the connector's internal stack.
+Normally, when a :class:`whad.device.connector.WhadDeviceConnector`
+(or any of its inherited classes) is used it may rely on a protocol stack to process
+outgoing and ingoing PDUs. By doing so, there is no way to get access to the received
+PDUs and avoid them to be forwarded to the connector's protocol stack.
 
-However, these connectors expose a method called :meth:`whad.ble.connector.Central.auto`
-that can enable or disable this automatic processing of PDUs. By default, the
-PDUs are passed to the underlying protocol stack, but a simple line of code
-can disable this behavior:
+However, all connectors expose a method called :meth:`whad.device.connector.WhadDeviceConnector.enable_synchronous`
+that can enable or disable this automatic processing of PDUs. By default,
+PDUs are passed to the underlying protocol stack but we can force the connector
+to keep them in a queue and to wait for us to retrieve them:
 
 .. code:: python
 
     # Disable automatic PDU processing
-    central.auto(False)
+    central.enable_synchronous(True)
 
-Once this automatic processing disabled, every received PDU is then stored by
-the connector in a dedicated queue, and can be retrieved using a method called
-:py:meth:`whad.ble.connector.Central.wait_pdu`. This method is by default synchronous
-and will return only when a PDU has been received and put in queue.
+With the connector set in synchronous mode, every received PDU is then stored by
+the connector in a dedicated queue and can be retrieved using 
+:py:meth:`whad.device.connector.WhadDeviceConnector.wait_packet`.
+This method requires the connector to be in synchronous mode and will return
+a PDU from the connector's queue, or `None` if the queue is empty once the
+specified timeout period expired.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -83,3 +83,11 @@ Welcome to WHAD's documentation!
     :caption: Contributing
 
     device/firmware
+
+
+.. toctree::
+    :maxdepth: 1
+    :caption: Python API Reference
+
+    api/device
+    api/monitors

--- a/whad/device/device.py
+++ b/whad/device/device.py
@@ -292,27 +292,17 @@ class WhadDevice:
     @classmethod
     def create(cls, interface_string):
         '''
-        Allows to get a specific device according to the provided interface string.
-        The interface string is formed as follow:
+        Create a specific device according to the provided interface string,
+        formed as follows:
 
-        "<device_type>[device_index][:device_identifier]"
+        <device_type>[device_index][:device_identifier]
 
         Examples:
-            * Instantiating the first available UartDevice:
-                "uart" or "uart0"
-
-            * Instantiating the second available UartDevice:
-                "uart1"
-
-            * Instantiating an UartDevice linked to /dev/ttyACM0:
-                "uart:/dev/ttyACM0"
-
-            * Instantiating the first available UbertoothDevice:
-                "ubertooth" or "ubertooth0"
-
-            * Instantiating an UbertoothDevice with serial number
-              "11223344556677881122334455667788":
-                ubertooth:11223344556677881122334455667788
+            - `uart` or `uart0`: defines the first compatible UART device available
+            - `uart1`: defines the second compatible UART device available
+            - `uart:/dev/ttyACMO`: defines a compatible UART device identified by `/dev/tty/ACMO`
+            - `ubertooth` or `ubertooth0`: defines the first available Ubertooth device
+            - `ubertooth:11223344556677881122334455667788`: defines a Ubertooth device with serial number *11223344556677881122334455667788*
         '''
         device_classes = cls._get_sub_classes()
 


### PR DESCRIPTION
Project documentation contained an outdated example code in the Bluetooth Low Energy "Get Started" section using some methods that have been removed from our BLE `Central` connector.

This example code has been fixed to use the new generic connector's synchronous mode and `WhadDeviceConnector` and `WhadDevice` classes have also been added to the documentation in a dedicated `Python API Reference` (still incomplete) in order to have working links from this BLE example to the corresponding classes methods and related docstrings.

Some docstrings have been fixed to avoid errors/warnings when building documentation.