### PR TITLE
BLE stack now supports generic characteristic descriptor discovery (fixes #182)

### DIFF
--- a/whad/ble/profile/__init__.py
+++ b/whad/ble/profile/__init__.py
@@ -558,12 +558,16 @@ class GenericProfile:
 
                             # Loop on descriptors for the current characteristic
                             for desc in charac['descriptors']:
+                                # Try to convert this descriptor to an instance
+                                # of one of our supported descriptors
                                 desc_obj = BleCharacteristicDescriptor.from_uuid(
                                     charac_obj,
                                     handle=desc['handle'],
                                     uuid=UUID(desc['uuid']),
                                     value=bytes.fromhex(desc['value']) if 'value' in desc else b''
                                 )
+
+                                # Add descriptor
                                 if desc_obj is not None:
                                     charac_obj.add_descriptor(desc_obj)
                                     self.register_attribute(desc_obj)

--- a/whad/ble/profile/characteristic.py
+++ b/whad/ble/profile/characteristic.py
@@ -90,8 +90,9 @@ class CharacteristicDescriptor(Attribute):
             cls = CharacteristicDescriptor.desc_types[uuid_value]
             return cls.from_value(characteristic, handle, value)
 
-        # Cannot find any class matching the provided UUID.
-        return None
+        # Cannot find any class matching the provided UUID, return a generic
+        # descriptor.
+        return CharacteristicDescriptor(characteristic, uuid, handle, value)
 
 @desc_type(UUID(0x2902))
 class ClientCharacteristicConfig(CharacteristicDescriptor):

--- a/whad/ble/stack/gatt/__init__.py
+++ b/whad/ble/stack/gatt/__init__.py
@@ -790,6 +790,21 @@ class GattClient(GattLayer):
 
                 handle += 1
 
+    def get_descriptor(self, characteristic: Characteristic, uuid: UUID, handle: int) -> CharacteristicDescriptor:
+        """Read a characteristic descriptor identified by its handle.
+
+        @param handle: Descriptor handle
+        @type handle: int
+        @return Characteristic descriptor
+        @rtype CharacteristicDescriptor
+        """
+        # Read descriptor value
+        desc_value = self.read(handle)
+
+        # Return descriptor object based on value and UUID
+        return CharacteristicDescriptor.from_uuid(characteristic, handle,
+                                                      uuid, desc_value)
+
     def discover(self, save_values: bool = False):
         # Discover services
         services = []
@@ -805,13 +820,9 @@ class GattClient(GattLayer):
         for service in self.__model.services():
             for characteristic in service.characteristics():
                 for descriptor in self.discover_characteristic_descriptors(characteristic):
-                    if descriptor.uuid == UUID(0x2902):
-                        characteristic.add_descriptor(
-                            ClientCharacteristicConfig(
-                                characteristic,
-                                handle=descriptor.handle
-                            )
-                        )
+                    desc = self.get_descriptor(characteristic, descriptor.uuid, descriptor.handle)
+                    if desc is not None:
+                        characteristic.add_descriptor(desc)
 
     @proclock
     def read(self, handle):


### PR DESCRIPTION
WHAD's BLE stack discovery process included *ClientCharacteristicConfiguration* descriptor (CCCD) discovery only, missing other descriptors like the *CharacteristicUserDescription* descriptor. 
The BLE stack's GATT layer now discovers all descriptors and read their values, mapping them to existing classes whenever it is possible to provide users with an easy way to manipulate the data stored in each descriptor's value.

GATT profile export and import features have also been modified to include this information and use it when cloning a device or simply using a JSON profile.