### PR TITLE
Fixed deadlock in GATT procedure handling when timeout is reached  (Fixes #201)

### DIFF
--- a/whad/ble/stack/gatt/__init__.py
+++ b/whad/ble/stack/gatt/__init__.py
@@ -46,6 +46,9 @@ def proclock(f):
         except AttError as err:
             self.procedure_stop()
             raise err
+        except GattTimeoutException as err:
+            self.procedure_stop()
+            raise err
         
         # Release GATT procedure lock
         self.procedure_stop()


### PR DESCRIPTION
`GattTimeoutException` was not caught by our `proclock` decorator and this kept the lock acquired, blocking any further GATT procedure.