### PR TITLE
Fixed a hang in user_transform() due to a recent change in connectors.

### DIFF
--- a/whad/tools/user.py
+++ b/whad/tools/user.py
@@ -130,7 +130,6 @@ class UserTransformApp(CommandLineApp):
                 if self.is_stdout_piped():
                     unix_server = UnixConnector(UnixSocketServerDevice(parameters=parameters))
 
-
                     while not unix_server.device.opened:
                         if unix_server.device.timedout:
                             return
@@ -147,6 +146,9 @@ class UserTransformApp(CommandLineApp):
 
                 else:
                     connector.on_packet = self.on_rx_packet
+
+                # Once configured, unlock connector to enable packet processing
+                connector.unlock()
 
                 # Keep running while interface is active
                 while interface.opened:


### PR DESCRIPTION
A recent refactoring of WHAD default connector lead us to disable packet processing by default (in *locked* state), keeping received packet in a dedicated queue, and let packet consumers  unlock it when they are ready to process incoming packets. This way, packets are not lost due to latency between tools, especially when they are chained through our piping mechanism in command line.