### PR TITLE
Fixed multiple bugs in winject, wplay and PHY injector (Fixes #208)

### DIFF
--- a/whad/exceptions.py
+++ b/whad/exceptions.py
@@ -127,6 +127,10 @@ class WhadDeviceError(Exception):
 
     def __str__(self):
         return f"WhadDeviceError({self.__message})"
+    
+    @property
+    def message(self) -> str:
+        return self.__message
 
 # External tools exceptions
 

--- a/whad/phy/connector/injector.py
+++ b/whad/phy/connector/injector.py
@@ -6,6 +6,7 @@ from whad.phy import Endianness
 from whad.hub.phy import Modulation as PhyModulation, Endianness as PhyEndianness
 from whad.phy.injecting import InjectionConfiguration
 from whad.phy.exceptions import NoModulation
+from whad.scapy.layers.phy import Phy_Packet
 from whad.exceptions import UnsupportedCapability
 
 # TODO: every sniffer is broken (sniff() method does not catch packets, we
@@ -82,7 +83,8 @@ class Injector(Phy):
         self.start()
 
     def inject(self, packet):
-
+        """Send packet through hardware.
+        """
         if not self._metadata_check:
             if hasattr(packet, "metadata") and hasattr(packet.metadata, "modulation") and packet.metadata.modulation is not None:
                 deviation = packet.metadata.deviation
@@ -135,4 +137,5 @@ class Injector(Phy):
                 self.start()
                 self._metadata_check = True
 
-        super().send(packet)
+        # Send packet payload
+        super().send(packet[Phy_Packet])

--- a/whad/phy/connector/injector.py
+++ b/whad/phy/connector/injector.py
@@ -65,7 +65,7 @@ class Injector(Phy):
                 self.__configuration.lora_configuration.spreading_factor,
                 self.__configuration.lora_configuration.coding_rate,
                 self.__configuration.lora_configuration.bandwidth,
-                12,
+                self.__configuration.lora_configuration.preamble_length,
                 crc=self.__configuration.lora_configuration.enable_crc,
                 explicit=self.__configuration.lora_configuration.enable_explicit_mode
             )

--- a/whad/phy/injecting.py
+++ b/whad/phy/injecting.py
@@ -20,12 +20,14 @@ class LoRaConfiguration:
     :param bandwidth: select the bandwidth (bw)
     :param enable_crc: enable LoRa CRC (crc)
     :param enable_explicit_mode: enable LoRa explicit mode (em)
+    :param preamble_length: set LoRa preamble length in symbols (pl)
     """
     spreading_factor : int = 7
     coding_rate : int = 45
     bandwidth : int = 125000
     enable_crc: bool = False
     enable_explicit_mode: bool = False
+    preamble_length: int = 12
 
 
 @dataclass

--- a/whad/tools/winject.py
+++ b/whad/tools/winject.py
@@ -93,7 +93,11 @@ class WhadInjectApp(CommandLineApp):
         self._input_queue = Queue()
         self._repeat_queue = Queue()
 
-        # Don't build yet if piped
+        # Load implemented injectors (introspection)
+        self.environment = None
+
+        # Build subparsers if stdin is not piped, when piped we will do
+        # it in the pre_run() method.
         if not self.is_stdin_piped():
             self.subparsers = self.add_subparsers(
                 required=True,
@@ -101,7 +105,7 @@ class WhadInjectApp(CommandLineApp):
                 parser_class=WhadDomainSubParser,
                 help='Domain in use'
             )
-
+            self.environment = list_implemented_injectors()
             self.build_subparsers(self.subparsers)
         else:
             self.subparsers = None
@@ -116,7 +120,6 @@ class WhadInjectApp(CommandLineApp):
             domain["parameters"] = get_injector_parameters(
                 domain["configuration_class"]
             )
-
 
             domain["subparser"] = subparsers.add_parser(
                 domain_name,
@@ -248,14 +251,14 @@ class WhadInjectApp(CommandLineApp):
             self.print_help()
             sys.exit(1)
 
-
         error_func = self.error
         if self.subparsers is None:
             self.error  = lambda m : None
 
         # Load implemented injectors *before* calling super().__init__()
-        # drastically improves performances.
-        self.environment = list_implemented_injectors()      
+        # drastically improves performances... and I have no clue why o_o
+        if self.environment is None:
+            self.environment = list_implemented_injectors()
 
         # Call CLI app pre-run: it will initialize our source interface
         super().pre_run()
@@ -279,13 +282,17 @@ class WhadInjectApp(CommandLineApp):
                 help='Domain in use'
             )
 
+            # We build subparsers.
             self.build_subparsers(self.subparsers)
 
+            # And we inject the domain parameter retrieved from the parameters
+            # given by the input tool through the Unix socket URI.
             if domain not in start_argv and domain not in end_argv:
                 sys.argv = start_argv + [domain] + end_argv
             else:
                 sys.argv = start_argv + end_argv
 
+            # Parse winject arguments and propagate into the `self.args` namespace.
             for k, v in self.parse_args().__dict__.items():
                 setattr(self.args, k, v)
 
@@ -293,6 +300,7 @@ class WhadInjectApp(CommandLineApp):
         if not self.args.nocolor:
             conf.color_theme = BrightTheme()
 
+        # Generate packets if provided through commandline
         self.generate_packets()
 
 
@@ -316,7 +324,7 @@ class WhadInjectApp(CommandLineApp):
         injector = None
         # Launch pre-run tasks
         self.pre_run()
-        
+
         try:
             # We need to have an interface specified
             if self.interface is not None:

--- a/whad/tools/winject.py
+++ b/whad/tools/winject.py
@@ -110,8 +110,6 @@ class WhadInjectApp(CommandLineApp):
         """
         Generate the subparsers argument according to the environment.
         """
-        # List every domain implementing an injector
-        self.environment = list_implemented_injectors()
 
         # Iterate over domain, and get the associated sniffer parameters
         for domain_name, domain in self.environment.items():
@@ -254,7 +252,14 @@ class WhadInjectApp(CommandLineApp):
         error_func = self.error
         if self.subparsers is None:
             self.error  = lambda m : None
+
+        # Load implemented injectors *before* calling super().__init__()
+        # drastically improves performances.
+        self.environment = list_implemented_injectors()      
+
+        # Call CLI app pre-run: it will initialize our source interface
         super().pre_run()
+
         try:
             domain = self.args.domain
         except AttributeError:
@@ -290,6 +295,7 @@ class WhadInjectApp(CommandLineApp):
 
         self.generate_packets()
 
+
     def is_input_alive(self) -> bool:
         """Determine if the input interface is providing packets to inject.
 
@@ -310,7 +316,7 @@ class WhadInjectApp(CommandLineApp):
         injector = None
         # Launch pre-run tasks
         self.pre_run()
-
+        
         try:
             # We need to have an interface specified
             if self.interface is not None:
@@ -324,7 +330,6 @@ class WhadInjectApp(CommandLineApp):
 
 
                     if self.is_piped_interface():
-
                         connector = UnixConnector(self.input_interface)
 
                         connector.domain = self.args.domain

--- a/whad/tools/wplay.py
+++ b/whad/tools/wplay.py
@@ -14,7 +14,7 @@ from whad.cli.app import run_app
 from whad.common.pcap import extract_pcap_metadata
 
 from whad.device import WhadDevice
-from whad.exceptions import WhadDeviceNotFound
+from whad.exceptions import WhadDeviceNotFound, WhadDeviceError
 from whad.tools.utils import list_implemented_sniffers
 from whad.tools.wsniff import WhadSniffApp
 
@@ -99,6 +99,9 @@ class WhadPlayApp(WhadSniffApp):
             super().run()
         except WhadDeviceNotFound:
             self.error("PCAP file not found")
+        except WhadDeviceError as err:
+            # Generally raised when PCAP file is not supported
+            self.error(err.message)
 
 def wplay_main():
     """Launcher for wplay.


### PR DESCRIPTION
- winject had multiple performance issues caused by some parts of its code that took too long to execute
- wplay did not display any error when provided with an unsupported PCAP file
- PHY injector sent both packet header and payload but was supposed to send only the provided payload