### PR TITLE
Added support for profile option in wble-periph when used in script  mode

### DIFF
--- a/whad/ble/cli/peripheral/commands/shell.py
+++ b/whad/ble/cli/peripheral/commands/shell.py
@@ -1,6 +1,8 @@
 """BLE peripheral emulation interactive shell
 """
+import json
 from binascii import unhexlify, Error as BinasciiError
+
 from whad.cli.app import command
 from whad.ble.cli.peripheral.shell import BlePeriphShell
 
@@ -56,6 +58,14 @@ def interactive_handler(app, _):
             # Read profile
             with open(app.args.profile,'rb') as f:
                 profile_json = f.read()
+            try:
+                if not check_profile(json.loads(profile_json)):
+                    app.error("Invalid JSON file (does not contain a valid GATT profile).")
+                    profile_json = None
+            except json.decoder.JSONDecodeError as parsing_err:
+                app.error((f"Invalid JSON file, parsing error line {parsing_err.lineno}: "
+                          f"{parsing_err.msg}"))
+                app.exit()
         else:
             profile_json = None
 


### PR DESCRIPTION
Profile option `--profile` is part of `wble-periph` command-line options but discarded when a script is used.

This PR adds support for this option and allows populating the emulated device's advertising data and GATT profile before running a script.