### PR TITLE
Improves CLUES database loading (solves #229)

### DIFF
--- a/whad/ble/cli/central/__init__.py
+++ b/whad/ble/cli/central/__init__.py
@@ -19,6 +19,8 @@ $ wble-central sniff <bd address> -> capture connections to this device and save
 import logging
 from whad.cli.app import CommandLineApp, run_app
 
+from whad.ble.utils.clues import CluesDb
+
 from .shell import BleCentralShell
 from .commands import *
 
@@ -89,6 +91,9 @@ class BleCentralApp(CommandLineApp):
         # Launch pre-run tasks
         logger.debug("Executing pre-run hook")
         self.pre_run()
+
+        # Pre-load CluesDb
+        CluesDb.load_data()
 
         logger.debug("Executing main code")
         if self.args.script is not None:

--- a/whad/ble/cli/central/__init__.py
+++ b/whad/ble/cli/central/__init__.py
@@ -93,7 +93,8 @@ class BleCentralApp(CommandLineApp):
         self.pre_run()
 
         # Pre-load CluesDb
-        CluesDb.load_data()
+        if not CluesDb.load_data():
+            self.error("CLUES database could not be loaded, did you use `--recurse-submodules` when cloning the repository ?")
 
         logger.debug("Executing main code")
         if self.args.script is not None:

--- a/whad/ble/cli/peripheral/__init__.py
+++ b/whad/ble/cli/peripheral/__init__.py
@@ -4,6 +4,7 @@ import json
 
 from whad.cli.app import CommandLineApp, run_app
 from whad.ble.cli.peripheral.shell import BlePeriphShell
+from whad.ble.utils.clues import CluesDb
 
 from .commands.shell import interactive_handler, check_profile
 
@@ -50,6 +51,9 @@ class BlePeriphApp(CommandLineApp):
         """
         # Launch pre-run tasks
         self.pre_run()
+
+        # Preload CluesDb
+        CluesDb.load_data()
 
         if self.args.script is not None:
             # If a profile has been provided, load it

--- a/whad/ble/cli/peripheral/__init__.py
+++ b/whad/ble/cli/peripheral/__init__.py
@@ -53,7 +53,8 @@ class BlePeriphApp(CommandLineApp):
         self.pre_run()
 
         # Preload CluesDb
-        CluesDb.load_data()
+        if not CluesDb.load_data():
+            self.error("CLUES database could not be loaded, did you use `--recurse-submodules` when cloning the repository ?")
 
         if self.args.script is not None:
             # If a profile has been provided, load it

--- a/whad/ble/profile/characteristic.py
+++ b/whad/ble/profile/characteristic.py
@@ -380,7 +380,6 @@ class Characteristic(Attribute):
         if alias is not None:
             return f"{alias} (0x{self.__charac_uuid})"
 
-        
         # Search in collaborative CLUES database
         alias = CluesDb.get_uuid_alias(self.__charac_uuid)
         if alias is not None:

--- a/whad/ble/utils/clues.py
+++ b/whad/ble/utils/clues.py
@@ -37,12 +37,13 @@ class CluesDb:
     """DarkMentorLLC Clues collaborative database.
     """
     CLUES_CACHE = []
+    loaded = False
 
     @staticmethod
     def load_data():
         """Load data from CLUES_data.json file
         """
-        if len(CluesDb.CLUES_CACHE) == 0:
+        if not CluesDb.loaded:
             # Load data from CLUES_data.json into cache
             clues_data_path = os.path.join(resources.files("whad"),
                                            "resources/clues/CLUES_data.json")
@@ -56,7 +57,8 @@ class CluesDb:
                     logger.error("[!] Cannot read CLUES database, please check permissions.")
             else:
                 logger.error("[!] CLUES database not found, did you clone WHAD's repository with --recurse-submodules ?")
-
+        # Mark DB as loaded, even if it failed (avoiding multiple error messages).
+        CluesDb.loaded = True
 
     @staticmethod
     def get_uuid_alias(uuid: UUID) -> str:

--- a/whad/ble/utils/clues.py
+++ b/whad/ble/utils/clues.py
@@ -40,9 +40,11 @@ class CluesDb:
     loaded = False
 
     @staticmethod
-    def load_data():
+    def load_data() -> bool:
         """Load data from CLUES_data.json file
         """
+        result = False
+
         if not CluesDb.loaded:
             # Load data from CLUES_data.json into cache
             clues_data_path = os.path.join(resources.files("whad"),
@@ -53,12 +55,21 @@ class CluesDb:
                 try:
                     with open(clues_data_path, 'r', encoding="utf-8") as clues_json:
                         CluesDb.CLUES_CACHE = json.load(clues_json)
+
+                    # Success
+                    result = True
                 except IOError:
-                    logger.error("[!] Cannot read CLUES database, please check permissions.")
+                    logger.debug("[cluesdb] input/output error while trying to open file %s", clues_data_path)
+                    logger.error("CLUES database could not be loaded (read error)")
             else:
-                logger.error("[!] CLUES database not found, did you clone WHAD's repository with --recurse-submodules ?")
+                logger.debug("[cluesdb] missing database file CLUES_data.json, expected path: %s", clues_data_path)
+                logger.error("CLUES database could not be be found (missing file)")
+
         # Mark DB as loaded, even if it failed (avoiding multiple error messages).
         CluesDb.loaded = True
+
+        # Return operation result
+        return result
 
     @staticmethod
     def get_uuid_alias(uuid: UUID) -> str:

--- a/whad/ble/utils/clues.py
+++ b/whad/ble/utils/clues.py
@@ -2,10 +2,13 @@
 """
 import json
 import os.path
+import logging
 
 from importlib import resources
 
 from whad.ble.profile.attribute import UUID
+
+logger = logging.getLogger(__name__)
 
 def uuid_match(uuid: UUID, pattern: str) -> bool:
     """Determine if the provided UUID matches the pattern.
@@ -43,8 +46,17 @@ class CluesDb:
             # Load data from CLUES_data.json into cache
             clues_data_path = os.path.join(resources.files("whad"),
                                            "resources/clues/CLUES_data.json")
-            with open(clues_data_path, 'r', encoding="utf-8") as clues_json:
-                CluesDb.CLUES_CACHE = json.load(clues_json)
+
+            # Ensure the database file is present
+            if os.path.exists(clues_data_path):
+                try:
+                    with open(clues_data_path, 'r', encoding="utf-8") as clues_json:
+                        CluesDb.CLUES_CACHE = json.load(clues_json)
+                except IOError:
+                    logger.error("[!] Cannot read CLUES database, please check permissions.")
+            else:
+                logger.error("[!] CLUES database not found, did you clone WHAD's repository with --recurse-submodules ?")
+
 
     @staticmethod
     def get_uuid_alias(uuid: UUID) -> str:


### PR DESCRIPTION
WHAD has a single submodule that may not be correctly initialized and updated if the respoitory is not cloned with the `--recurse-submodules` git option. This submodule is not critical as it provides information about BLE GATT services and characteristics based on their UUIDs, but WHAD kept crashing if a specific JSON file located in this submodule cannot be loaded.

The code handling this external database has been modified to:
- avoid crashes when the database cannot be loaded
- display an error through Python's logging module when loading failed
- force wble-central and wble-periph  CLI tools to preload this database and display an error in addition to the one showed by Python's logging module telling the user to check if the repository has been correctly cloned with the  `--recurse-submodules` option.