### PR TITLE
tests/protocol/ble: use relative imports

### DIFF
--- a/tests/protocol/ble/test_ble_parsing.py
+++ b/tests/protocol/ble/test_ble_parsing.py
@@ -13,9 +13,9 @@ from whad.hub.ble import BleDomain, SetBdAddress, SniffAdv, SniffConnReq, \
     Synchronized, Desynchronized, PrepareSequenceManual, PrepareSequenceConnEvt, \
     PrepareSequencePattern, Injected, Trigger, Triggered, DeleteSequence, SetEncryption
 
-from tests.protocol.ble.test_ble_hijack import hijack_master, hijack_slave, hijack_both, hijacked
-from tests.protocol.ble.test_ble_pdu import send_ble_pdu, send_ble_raw_pdu, raw_pdu, ble_pdu, ble_adv_pdu, set_adv_data
-from tests.protocol.ble.test_ble_prepseq import prep_seq_manual, prep_seq_connevt, prep_seq_reception, ble_trigger, \
+from .test_ble_hijack import hijack_master, hijack_slave, hijack_both, hijacked
+from .test_ble_pdu import send_ble_pdu, send_ble_raw_pdu, raw_pdu, ble_pdu, ble_adv_pdu, set_adv_data
+from .test_ble_prepseq import prep_seq_manual, prep_seq_connevt, prep_seq_reception, ble_trigger, \
     ble_triggered, ble_delete_seq
 
 BD_ADDRESS_DEFAULT = bytes([0x11, 0x22, 0x33, 0x44, 0x55, 0x66])


### PR DESCRIPTION
When using my distribution `pytest` rather than `tox`, I get the following crash:
```
ImportError while importing test module '<redacted>/whad-client/tests/protocol/ble/test_ble_parsing.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
<redacted>/lib/python3.12/importlib/__init__.py:90: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/protocol/ble/test_ble_parsing.py:16: in <module>
    from tests.protocol.ble.test_ble_hijack import hijack_master, hijack_slave, hijack_both, hijacked
E   ModuleNotFoundError: No module named 'tests'
```

Creating a `__init__.py` file then using relative imports fixes this bug.