### PR TITLE
Use frombytes/hex rather than hexlify

### DIFF
--- a/tests/domain/lorawan/test_crypto.py
+++ b/tests/domain/lorawan/test_crypto.py
@@ -1,5 +1,4 @@
 import pytest
-from binascii import unhexlify, hexlify
 from whad.lorawan.crypto import derive_appskey, derive_nwkskey, decrypt_packet, encrypt_packet
 from whad.scapy.layers.lorawan import PHYPayload, JoinAccept, JoinRequest, MACPayloadUplink
 from scapy.all import RawVal
@@ -8,11 +7,11 @@ class TestLoRaWANCrypto:
 
     @pytest.fixture
     def appkey(self):
-        return unhexlify('00000000000000000000000000000000')
+        return bytes.fromhex("00000000000000000000000000000000")
     
     @pytest.fixture
     def encrypted_join_accept(self):
-        return unhexlify('20fed423bb9faca7e68a967a02fde49c41')
+        return bytes.fromhex("20fed423bb9faca7e68a967a02fde49c41")
 
     def test_encrypt_join_accept(self, appkey, encrypted_join_accept):
         """Test encryption of Join Accept

--- a/whad/ble/cli/ble_connect.py
+++ b/whad/ble/cli/ble_connect.py
@@ -67,7 +67,7 @@ class BleConnectInputPipe(Bridge):
     def dispatch_pending_input_pdu(self, message):
         """Dispatch pending PDU.
         """
-        logger.info("Dispatching input pdu %s" % message)
+        logger.info("Dispatching input pdu %s", message)
 
         # Send message to our chained tool
         command = self.convert_packet_message(message, self.__out_handle)
@@ -76,7 +76,7 @@ class BleConnectInputPipe(Bridge):
     def dispatch_pending_output_pdu(self, message):
         """Dispatch pending out PDUs (received)
         """
-        logger.info("Dispatching output pdu %s" % message)
+        logger.info("Dispatching output pdu %s", message)
         self.input.send_message(message)
 
     def convert_packet_message(self, message, conn_handle: int):

--- a/whad/ble/cli/central/commands/emulate.py
+++ b/whad/ble/cli/central/commands/emulate.py
@@ -2,7 +2,6 @@
 """
 from json import loads
 
-from binascii import unhexlify, Error as BinasciiError
 from prompt_toolkit import print_formatted_text, HTML
 
 from hexdump import hexdump
@@ -103,8 +102,8 @@ def check_profile(profile):
     if 'adv_data' not in profile['devinfo']:
         return False
     try:
-        unhexlify(profile['devinfo']['adv_data'])
-    except BinasciiError:
+        bytes.fromhex(profile["devinfo"]["adv_data"])
+    except ValueError:
         return False
 
     # Make sure we have a valid scan_rsp entry (if provided)
@@ -112,8 +111,8 @@ def check_profile(profile):
         return False
     if profile['devinfo']['scan_rsp'] is not None:
         try:
-            unhexlify(profile['devinfo']['scan_rsp'])
-        except BinasciiError:
+            bytes.fromhex(profile["devinfo"]["scan_rsp"])
+        except ValueError:
             return False
 
     # Make sure we have a BD address
@@ -149,8 +148,8 @@ def emulate_handler(app, command_args):
             # Check profile and emulate if everything is OK
             if check_profile(profile):
                 # Load device info
-                device_adv_data = unhexlify(profile['devinfo']['adv_data'])
-                device_scan_rsp = unhexlify(profile['devinfo']['scan_rsp'])
+                device_adv_data = bytes.fromhex(profile["devinfo"]["adv_data"])
+                device_scan_rsp = bytes.fromhex(profile["devinfo"]["scan_rsp"])
 
                 # Create a profile
                 device_profile = MonitoringProfile(from_json = profile_json)

--- a/whad/ble/cli/central/commands/profile.py
+++ b/whad/ble/cli/central/commands/profile.py
@@ -1,7 +1,6 @@
 """BLE profile command handler
 """
 from json import loads, dumps
-from binascii import hexlify
 from argparse import Namespace
 
 from prompt_toolkit import print_formatted_text, HTML
@@ -155,15 +154,13 @@ def profile_handler(app, command_args):
 
         # Generate device advertising information
         device_metadata = {
-            'adv_data': hexlify(device.adv_records.to_bytes()).decode('utf-8'),
-            'bd_addr': str(device.address),
-            'addr_type': device.address_type,
-            'scan_rsp': None
+            "adv_data": device.adv_records.to_bytes().hex(),
+            "bd_addr": str(device.address),
+            "addr_type": device.address_type,
+            "scan_rsp": None
         }
         if device.scan_rsp_records is not None:
-            device_metadata['scan_rsp'] = (
-                hexlify(device.scan_rsp_records.to_bytes()).decode('utf-8')
-            )
+            device_metadata["scan_rsp"] = device.scan_rsp_records.to_bytes().hex()
 
         scanner.stop()
 

--- a/whad/ble/cli/central/commands/write.py
+++ b/whad/ble/cli/central/commands/write.py
@@ -1,7 +1,5 @@
 """BLE characteristic write command handler
 """
-from binascii import unhexlify, Error as BinasciiError
-
 from whad.cli.app import command
 from whad.hub.ble.bdaddr import BDAddress
 from whad.ble.profile.attribute import UUID, InvalidUUIDException
@@ -223,8 +221,8 @@ def perform_write(app, device, args, without_response=False, profile_loaded=Fals
         # Decode hex data
         hex_data = ''.join(args[2:])
         try:
-            char_value = unhexlify(hex_data.replace('\t',''))
-        except BinasciiError:
+            char_value = bytes.fromhex(hex_data.replace("\t", ""))
+        except ValueError:
             app.error("Provided hex value contains non-hex characters.")
             return
     else:

--- a/whad/ble/cli/central/shell.py
+++ b/whad/ble/cli/central/shell.py
@@ -4,7 +4,6 @@ import re
 import html
 
 from typing import List
-from binascii import unhexlify, Error as BinasciiError
 
 from prompt_toolkit import print_formatted_text, HTML
 from hexdump import hexdump
@@ -805,8 +804,8 @@ class BleCentralShell(InteractiveShell):
             # Decode hex data
             hex_data = ''.join(args[2:])
             try:
-                char_value = unhexlify(hex_data.replace('\t',''))
-            except BinasciiError:
+                char_value = bytes.fromhex(hex_data.replace("\t", ""))
+            except ValueError:
                 self.error("Provided hex value contains non-hex characters.")
                 return
         else:
@@ -923,7 +922,7 @@ class BleCentralShell(InteractiveShell):
             try:
                 if len(args) >= 1:
                     hex_value = ''.join(args)
-                    raw_pdu = unhexlify(hex_value.replace(' ',''))
+                    raw_pdu = bytes.fromhex(hex_value.replace(" ", ""))
                     res = self.__connector.send_pdu(
                         BTLE_DATA(raw_pdu),
                         conn_handle=self.__target.conn_handle
@@ -932,7 +931,7 @@ class BleCentralShell(InteractiveShell):
                         self.error("An error occured while sending PDU.")
                 else:
                     self.error('Invalid hex value.')
-            except BinasciiError:
+            except ValueError:
                 self.error("Invalid hex value.")
             except ConnectionLostException:
                 self.error("Sending PDU failed (peripheral disconnected)")

--- a/whad/ble/cli/peripheral/commands/shell.py
+++ b/whad/ble/cli/peripheral/commands/shell.py
@@ -1,7 +1,6 @@
 """BLE peripheral emulation interactive shell
 """
 import json
-from binascii import unhexlify, Error as BinasciiError
 
 from whad.cli.app import command
 from whad.ble.cli.peripheral.shell import BlePeriphShell
@@ -20,8 +19,8 @@ def check_profile(profile):
     if 'adv_data' not in profile['devinfo']:
         return False
     try:
-        unhexlify(profile['devinfo']['adv_data'])
-    except BinasciiError:
+        bytes.fromhex(profile["devinfo"]["adv_data"])
+    except ValueError:
         return False
 
     # Make sure we have a valid scan_rsp entry (if provided)
@@ -29,8 +28,8 @@ def check_profile(profile):
         return False
     if profile['devinfo']['scan_rsp'] is not None:
         try:
-            unhexlify(profile['devinfo']['scan_rsp'])
-        except BinasciiError:
+            bytes.fromhex(profile["devinfo"]["scan_rsp"])
+        except ValueError:
             return False
 
     # Make sure we have a BD address

--- a/whad/ble/cli/peripheral/shell.py
+++ b/whad/ble/cli/peripheral/shell.py
@@ -2,7 +2,6 @@
 """
 import json
 from typing import Union, List, Tuple
-from binascii import unhexlify, Error as BinasciiError
 
 # pylint: disable-next=wildcard-import,unused-wildcard-import
 from scapy.layers.bluetooth4LE import *
@@ -1042,8 +1041,8 @@ class BlePeriphShell(InteractiveShell):
             # Decode hex data
             hex_data = ''.join(args[2:])
             try:
-                char_value = unhexlify(hex_data.replace("\t",''))
-            except BinasciiError:
+                char_value = bytes.fromhex(hex_data.replace("\t", ""))
+            except ValueError:
                 self.error("Provided hex value contains non-hex characters.")
                 return
         else:
@@ -1342,9 +1341,9 @@ class BlePeriphShell(InteractiveShell):
                         return
 
             try:
-                self.__adv_manager.manufacturer_data = (manuf_comp, unhexlify(manuf_data))
+                self.__adv_manager.manufacturer_data = (manuf_comp, bytes.fromhex(manuf_data))
                 self.success("Manufacturer data set.")
-            except BinasciiError:
+            except ValueError:
                 self.__manuf_data = []
                 self.error("Error while parsing manufacturer data (not valid hex)")
             except AdvDataFieldListOverflow:

--- a/whad/ble/profile/attribute.py
+++ b/whad/ble/profile/attribute.py
@@ -1,7 +1,6 @@
 """BLE Attribute
 """
 from struct import pack, unpack
-from binascii import unhexlify, hexlify
 
 from whad.ble.exceptions import InvalidHandleValueException, InvalidUUIDException
 
@@ -542,14 +541,14 @@ class UUID:
 
         elif len(uuid) == 4:
             self.uuid = uuid
-            self.packed = unhexlify(uuid)[::-1]
+            self.packed = bytes.fromhex(uuid)[::-1]
             self.type = UUID.TYPE_16
         elif len(uuid) == 36:
             temp = uuid.replace('-','')
 
             if len(temp) == 32:
                 self.uuid = uuid
-                self.packed = unhexlify(temp)[::-1]
+                self.packed = bytes.fromhex(temp)[::-1]
                 self.type = UUID.TYPE_128
         elif len(uuid) == 32 and "-" not in uuid:
             self.uuid = b'-'.join((uuid[:8], uuid[8:12], uuid[12:16], uuid[16:20],
@@ -564,9 +563,8 @@ class UUID:
             self.type = UUID.TYPE_16
         elif len(uuid) == 16:
             r = uuid[::-1]
-            self.uuid = b'-'.join(map(lambda x: hexlify(x),
-                                      (r[0:4], r[4:6], r[6:8],r[8:10],
-                                       r[10:]))).decode('latin-1')
+            self.uuid = "-".join(map(lambda x: x.hex(),
+                                     (r[0:4], r[4:6], r[6:8],r[8:10], r[10:])))
             self.packed = uuid
             self.type = UUID.TYPE_128
 

--- a/whad/ble/stack/__init__.py
+++ b/whad/ble/stack/__init__.py
@@ -61,7 +61,7 @@ class BleStack(Layer):
         This callback handles a control PDU received from a connection
         identified by its connection handle `conn_handle`.
         '''
-        logger.debug('received a control PDU (%d bytes) for connection handle %d' % (len(pdu), conn_handle))
+        logger.debug("received a control PDU (%d bytes) for connection handle %d", len(pdu), conn_handle)
         # Notify link layer we received a control PDU for a given `conn_handle`.
         self.send('ll', pdu, tag='control', conn_handle=conn_handle)
 
@@ -72,7 +72,7 @@ class BleStack(Layer):
         This callback hanles a data PDU received from a connection identitied
         by its connection handle `conn_handle`.
         '''
-        logger.debug('received a data PDU (%d bytes) for conn_handle %d' % (len(pdu), conn_handle))
+        logger.debug("received a data PDU (%d bytes) for conn_handle %d", len(pdu), conn_handle)
         # Notify link layer we received a data PDU for a given `conn_handle`.
         self.send('ll', pdu, tag='data', conn_handle=conn_handle)
 
@@ -80,14 +80,14 @@ class BleStack(Layer):
     def send_data(self, data, conn_handle=None, encrypt=None):
         '''Send data to the underlying WHAD connector.
         '''
-        logger.debug('sending a data PDU (%d bytes) to conn_handle %d' % (len(data), conn_handle))
+        logger.debug("sending a data PDU (%d bytes) to conn_handle %d", len(data), conn_handle)
         return self.__connector.send_data_pdu(data, conn_handle=conn_handle, encrypt=encrypt)
 
     @source('ll', 'control')
     def send_control(self, pdu, conn_handle=None, encrypt=None):
         '''Send control PDU to the underlying WHAD connector.
         '''
-        logger.debug('sending a control PDU (%d bytes) to conn_handle %d' % (len(pdu), conn_handle))
+        logger.debug("sending a control PDU (%d bytes) to conn_handle %d", len(pdu), conn_handle)
         self.__connector.send_ctrl_pdu(pdu, conn_handle, encrypt=encrypt)
 
     @source('ll', tag='ATT_MTU')
@@ -99,7 +99,7 @@ class BleStack(Layer):
     def set_encryption(self, conn_handle=None, enabled=True,ll_key=None, ll_iv=None, key=None, rand=None, ediv=None):
         '''Enable or disable encryption using underlying WHAD connector.
         '''
-        logger.debug('%s encryption (key=%s, iv=%s)' % ("enabling" if enabled else "disabling", ll_key.hex(), ll_iv.hex()))
+        logger.debug("%s encryption (key=%s, iv=%s)", "enabling" if enabled else "disabling", ll_key.hex(), ll_iv.hex())
         self.__connector.set_encryption(
             conn_handle=conn_handle,
             enabled=enabled,

--- a/whad/ble/stack/gatt/__init__.py
+++ b/whad/ble/stack/gatt/__init__.py
@@ -128,7 +128,7 @@ class GattLayer(Layer):
         if packet_type in self.__handlers:
             self.__handlers[packet_type](packet)
         else:
-            logger.error('no GATT handler for packet type %s' % packet_type.__name__)
+            logger.error("no GATT handler for packet type %s", packet_type.__name__)
 
     def procedure_start(self):
         """
@@ -242,7 +242,7 @@ class GattLayer(Layer):
 
         :param GattFindByTypeValueRequest request: Request
         """
-        logger.debug('[gatt] FindByTypeValueRequest, start: %d, type: %s' % (request.start, request.type))
+        logger.debug("[gatt] FindByTypeValueRequest, start: %d, type: %s", request.start, request.type)
         self.error(
             BleAttOpcode.FIND_BY_TYPE_VALUE_REQUEST, request.start, BleAttErrorCode.ATTRIBUTE_NOT_FOUND
         )
@@ -751,7 +751,7 @@ class GattClient(GattLayer):
                             charac.value = b""
                         
                     handle = charac.handle+2
-                    logger.debug('found characteristic %s with handle %d' % (charac_uuid, charac_value_handle))
+                    logger.debug("found characteristic %s with handle %d", charac_uuid, charac_value_handle)
                     yield charac
 
             elif isinstance(msg, GattErrorResponse):

--- a/whad/ble/stack/llm/__init__.py
+++ b/whad/ble/stack/llm/__init__.py
@@ -2,7 +2,6 @@
 Bluetooth LE Stack Link-layer Manager
 """
 import logging
-from binascii import hexlify
 from struct import pack
 from random import randint
 from threading import Lock
@@ -717,9 +716,10 @@ class LinkLayer(Layer):
             skdm, ivm = self.state.get_skd_and_iv(conn_handle)
             rand, ediv = self.state.get_rand_and_ediv(conn_handle)
 
-            logger.info("[llm] Received LL_ENC_RSP: skds=%s ivs=%s",
-                hexlify(pack('<Q', enc_rsp.skds)),
-                hexlify(pack('<I', enc_rsp.ivs))
+            logger.info(
+                "[llm] Received LL_ENC_RSP: skds=%s ivs=%s",
+                pack('<Q', enc_rsp.skds).hex(),
+                pack('<I', enc_rsp.ivs).hex(),
             )
 
             logger.info('[llm] Initiate connection LinkLayerCryptoManager')
@@ -748,14 +748,14 @@ class LinkLayer(Layer):
             # Generate session key
             session_key = e(encryption_key, skd)
 
-            logger.info("[llm] master  skd: %s", hexlify(master_skd))
-            logger.info("[llm] master   iv: %s", hexlify(master_iv))
-            logger.info("[llm] slave   skd: %s", hexlify(slave_skd))
-            logger.info("[llm] slave    iv: %s", hexlify(slave_iv))
-            logger.info("[llm] Session  TK: %s", hexlify(encryption_key))
-            logger.info("[llm] Session  iv: %s", hexlify(iv))
-            logger.info("[llm] Exp. Ses iv: %s", hexlify(self.__llcm.iv))
-            logger.info("[llm] Session key: %s", hexlify(session_key))
+            logger.info("[llm] master  skd: %s", master_skd.hex())
+            logger.info("[llm] master   iv: %s", master_iv.hex())
+            logger.info("[llm] slave   skd: %s", slave_skd.hex())
+            logger.info("[llm] slave    iv: %s", slave_iv.hex())
+            logger.info("[llm] Session  TK: %s", encryption_key.hex())
+            logger.info("[llm] Session  iv: %s", iv.hex())
+            logger.info("[llm] Exp. Ses iv: %s", self.__llcm.iv.hex())
+            logger.info("[llm] Session key: %s", session_key.hex())
 
 
             # Notify encryption enabled
@@ -803,11 +803,12 @@ class LinkLayer(Layer):
             iv = randint(0, 0x100000000)
             self.state.register_skd_and_iv(conn_handle, skd, iv)
 
-            logger.info("[llm] Received LL_ENC_REQ: rand=%s ediv=%s skd=%s iv=%s",
-                hexlify(pack('<Q', enc_req.rand)),
-                hexlify(pack('<H', enc_req.ediv)),
-                hexlify(pack('<Q', enc_req.skdm)),
-                hexlify(pack('<I', enc_req.ivm)),
+            logger.info(
+                "[llm] Received LL_ENC_REQ: rand=%s ediv=%s skd=%s iv=%s",
+                pack('<Q', enc_req.rand).hex(),
+                pack('<H', enc_req.ediv).hex(),
+                pack('<Q', enc_req.skdm).hex(),
+                pack('<I', enc_req.ivm).hex(),
             )
 
             logger.info("[llm] Initiate connection LinkLayerCryptoManager")
@@ -839,18 +840,19 @@ class LinkLayer(Layer):
             # Generate session key
             session_key = e(encryption_key, skd)
 
-            logger.info("[llm] master  skd: %s", hexlify(master_skd))
-            logger.info("[llm] master   iv: %s", hexlify(master_iv))
-            logger.info("[llm] slave   skd: %s", hexlify(slave_skd))
-            logger.info("[llm] slave    iv: %s", hexlify(slave_iv))
-            logger.info("[llm] Session  TK: %s", hexlify(encryption_key))
-            logger.info("[llm] Session  iv: %s", hexlify(iv))
-            logger.info("[llm] Exp. Ses iv: %s", hexlify(self.__llcm.iv))
-            logger.info("[llm] Session key: %s", hexlify(session_key))
+            logger.info("[llm] master  skd: %s", master_skd.hex())
+            logger.info("[llm] master   iv: %s", master_iv.hex())
+            logger.info("[llm] slave   skd: %s", slave_skd.hex())
+            logger.info("[llm] slave    iv: %s", slave_iv.hex())
+            logger.info("[llm] Session  TK: %s", encryption_key.hex())
+            logger.info("[llm] Session  iv: %s", iv.hex())
+            logger.info("[llm] Exp. Ses iv: %s", self.__llcm.iv.hex())
+            logger.info("[llm] Session key: %s", session_key.hex())
             skdm, ivm = self.state.get_skd_and_iv(conn_handle)
-            logger.info("[llm] Send LL_ENC_RSP: skd=%s iv=%s",
-                hexlify(pack('<Q', skdm)),
-                hexlify(pack('<I', ivm))
+            logger.info(
+                "[llm] Send LL_ENC_RSP: skd=%s iv=%s",
+                pack('<Q', skdm).hex(),
+                pack('<I', ivm).hex(),
             )
 
             # Send back our parameters

--- a/whad/ble/stack/smp/__init__.py
+++ b/whad/ble/stack/smp/__init__.py
@@ -305,7 +305,7 @@ class SM_Peer(object):
         By default, peers are configured to only accept Legacy JustWorks pairing.
         """
 
-        logger.info('Initiate SM_Peer object for peer %s' % address)
+        logger.info("Initiate SM_Peer object for peer %s", address)
 
         # Peer address and address type
         self.__address = address
@@ -486,7 +486,7 @@ class SM_Peer(object):
             if self.__kd_sign_key:
                 keys.append('csrk')
                 self.__dist_csrk = True
-            logger.debug('Set distribute key for peer: %s' % (','.join(keys)))
+            logger.debug("Set distribute key for peer: %s", ",".join(keys))
         elif self.__pairing_method in [PM_LESC_JUSTWORKS, PM_LESC_NUMCOMP, PM_LESC_OOB]:
             keys=[]
             if self.__kd_id_key:
@@ -498,7 +498,7 @@ class SM_Peer(object):
             if self.__kd_link_key:
                 keys.append('ltk')
                 self.__dist_ltk = True
-            logger.debug('Set distribute key for peer: %s' % (','.join(keys)))
+            logger.debug("Set distribute key for peer: %s", ",".join(keys))
 
     def get_key_distribution(self):
         """Get the key distribution byte from the peer.
@@ -599,7 +599,7 @@ class SM_Peer(object):
         :param int pairing_method: Pairing method as defined in PM_* in BleSMP.
         """
         self.__pairing_method = pairing_method
-        logger.info('Pairing method set to %d' % self.__pairing_method)
+        logger.info("Pairing method set to %d", self.__pairing_method)
 
     @property
     def pairing_method(self):
@@ -1534,7 +1534,7 @@ class SMPLayer(Layer):
     def on_pairing_failed(self, pairing_failed):
         """Method called when a pairing failed is received.
         """
-        logger.info("Pairing failed (reason=%d)" % pairing_failed.reason)
+        logger.info("Pairing failed (reason=%d)", pairing_failed.reason)
         # Return to IDLE mode
         self.reset_state()
         self.state.last_failure = pairing_failed.reason
@@ -1583,8 +1583,8 @@ class SMPLayer(Layer):
                     ]
                 )
             )
-            logger.info("Computed EA: %s" % ea.hex())
-            logger.info("Received EA: %s" % dhkey_check.dhkey_check[::-1].hex())
+            logger.info("Computed EA: %s", ea.hex())
+            logger.info("Received EA: %s", dhkey_check.dhkey_check[::-1].hex())
             # If we received a valid EA, generate EB and transmit it
             if ea == dhkey_check.dhkey_check[::-1]:
                 eb = self.get_custom_function("compute_exchange_value")(
@@ -1650,8 +1650,8 @@ class SMPLayer(Layer):
                 )
             )
             # Compare it with the received data
-            logger.info("Computed EB: %s" % eb.hex())
-            logger.info("Received EB: %s" % dhkey_check.dhkey_check[::-1].hex())
+            logger.info("Computed EB: %s", eb.hex())
+            logger.info("Received EB: %s", dhkey_check.dhkey_check[::-1].hex())
 
             if eb == dhkey_check.dhkey_check[::-1]:
 
@@ -1875,7 +1875,7 @@ class SMPLayer(Layer):
             SecurityManagerState.STATE_LESC_PUBKEY_RECVD_STAGEN,
             SecurityManagerState.STATE_LESC_PAIRING_RANDOM_SENT_STAGEN
         ):
-            logger.info('Pairing Confirm value is expected, processing ... [iteration=%d]' % self.state.passkey_counter)
+            logger.info("Pairing Confirm value is expected, processing ... [iteration=%d]", self.state.passkey_counter)
 
             if self.state.passkey_counter == 1:
                 # Collect passkey entry
@@ -1903,7 +1903,7 @@ class SMPLayer(Layer):
             )
 
         elif self.state.state == SecurityManagerState.STATE_LESC_PAIRING_CONFIRM_SENT_STAGEN:
-            logger.info('Pairing Confirm value is expected, processing ... [iteration=%d]' % self.state.passkey_counter)
+            logger.info("Pairing Confirm value is expected, processing ... [iteration=%d]", self.state.passkey_counter)
 
             # Extract confirm value
             self.state.responder.confirm = confirm.confirm[::-1]
@@ -1918,7 +1918,7 @@ class SMPLayer(Layer):
             )
 
         else:
-            logger.info('Pairing Confirm dropped because current state is %d' % self.state.state)
+            logger.info("Pairing Confirm dropped because current state is %d", self.state.state)
 
             # Notify error
             error = SM_Failed(
@@ -1999,9 +1999,7 @@ class SMPLayer(Layer):
                     )
 
                 else:
-                    logger.info('Invalid Numeric comparison (expected %s)' % (
-                        str(value),
-                    ))
+                    logger.info("Invalid Numeric comparison (expected %s)", str(value))
 
                     # Send error
                     error = SM_Failed(
@@ -2051,9 +2049,7 @@ class SMPLayer(Layer):
                 logger.info("Accepted numeric comparison, continuing...")
                 self.state.state = SecurityManagerState.STATE_LESC_PAIRING_RANDOM_SENT
             else:
-                logger.info('Invalid Numeric comparison (expected %s)' % (
-                    str(value),
-                ))
+                logger.info("Invalid Numeric comparison (expected %s)", str(value))
 
                 # Send error
                 error = SM_Failed(
@@ -2305,7 +2301,7 @@ class SMPLayer(Layer):
                 self.state.last_failure = SM_ERROR_CONFIRM_VALUE_FAILED
 
         else:
-            logger.info('Pairing Random dropped because current state is %d' % self.state.state)
+            logger.info("Pairing Random dropped because current state is %d", self.state.state)
 
             # Notify error
             error = SM_Failed(
@@ -2499,26 +2495,26 @@ class SMPLayer(Layer):
         logger.info("Pairing done.")
         if self.is_initiator():
             if self.state.ltk is not None:
-                logger.info("Distributed LTK: %s" % self.state.ltk.hex())
+                logger.info("Distributed LTK: %s", self.state.ltk.hex())
             if self.state.rand is not None:
-                logger.info("Distributed RAND: %s" % self.state.rand.hex())
+                logger.info("Distributed RAND: %s", self.state.rand.hex())
             if self.state.ediv is not None:
-                logger.info("Distributed EDIV: %s" % hex(self.state.ediv))
+                logger.info("Distributed EDIV: %s", hex(self.state.ediv))
             if self.state.irk is not None:
-                logger.info("Distributed IRK: %s" % self.state.irk.hex())
+                logger.info("Distributed IRK: %s", self.state.irk.hex())
             if self.state.csrk is not None:
-                logger.info("Distributed CSRK: %s" % self.state.csrk.hex())
+                logger.info("Distributed CSRK: %s", self.state.csrk.hex())
 
             if self.state.responder.ltk is not None:
-                logger.info("Received LTK: %s" %  self.state.responder.ltk.hex())
+                logger.info("Received LTK: %s",  self.state.responder.ltk.hex())
             if self.state.responder.random is not None:
-                logger.info("Received RAND: %s" % self.state.responder.random.hex())
+                logger.info("Received RAND: %s", self.state.responder.random.hex())
             if self.state.responder.ediv is not None:
-                logger.info("Received EDIV: %s" % hex(self.state.responder.ediv))
+                logger.info("Received EDIV: %s", hex(self.state.responder.ediv))
             if self.state.responder.irk is not None:
-                logger.info("Received IRK: %s" % self.state.responder.irk.hex())
+                logger.info("Received IRK: %s", self.state.responder.irk.hex())
             if self.state.responder.csrk is not None:
-                logger.info("Received CSRK: %s" % self.state.responder.csrk.hex())
+                logger.info("Received CSRK: %s", self.state.responder.csrk.hex())
 
             # If bonding is enabled, we register in the security DB
             # both our own and the peer cryptographic material
@@ -2577,26 +2573,26 @@ class SMPLayer(Layer):
 
         else:
             if self.state.ltk is not None:
-                logger.info("Distributed LTK: %s" % self.state.ltk.hex())
+                logger.info("Distributed LTK: %s", self.state.ltk.hex())
             if self.state.rand is not None:
-                logger.info("Distributed RAND: %s" % self.state.rand.hex())
+                logger.info("Distributed RAND: %s", self.state.rand.hex())
             if self.state.ediv is not None:
-                logger.info("Distributed EDIV: %s" % hex(self.state.ediv))
+                logger.info("Distributed EDIV: %s", hex(self.state.ediv))
             if self.state.irk is not None:
-                logger.info("Distributed IRK: %s" % self.state.irk.hex())
+                logger.info("Distributed IRK: %s", self.state.irk.hex())
             if self.state.csrk is not None:
-                logger.info("Distributed CSRK: %s" % self.state.csrk.hex())
+                logger.info("Distributed CSRK: %s", self.state.csrk.hex())
 
             if self.state.initiator.ltk is not None:
-                logger.info("Received LTK: %s" % self.state.initiator.ltk.hex())
+                logger.info("Received LTK: %s", self.state.initiator.ltk.hex())
             if self.state.initiator.random is not None:
-                logger.info("Received RAND: %s" % self.state.initiator.random.hex())
+                logger.info("Received RAND: %s", self.state.initiator.random.hex())
             if self.state.initiator.ediv is not None:
-                logger.info("Received EDIV: %s" % hex(self.state.initiator.ediv))
+                logger.info("Received EDIV: %s", hex(self.state.initiator.ediv))
             if self.state.initiator.irk is not None:
-                logger.info("Received IRK: %s" % self.state.initiator.irk.hex())
+                logger.info("Received IRK: %s", self.state.initiator.irk.hex())
             if self.state.initiator.csrk is not None:
-                logger.info("Received CSRK: %s" % self.state.initiator.csrk.hex())
+                logger.info("Received CSRK: %s", self.state.initiator.csrk.hex())
 
             # If bonding is enabled, we register in the security DB
             # both our own and the peer cryptographic material

--- a/whad/ble/stack/smp/__init__.py
+++ b/whad/ble/stack/smp/__init__.py
@@ -13,7 +13,6 @@ BleSMP provides these different pairing strategies:
 # refactoring, maybe some states can be merged
 
 from struct import pack, unpack
-from binascii import hexlify
 from random import randint
 from time import sleep
 
@@ -616,10 +615,7 @@ class SM_Peer(object):
         """
         # Rand
         self.__rand = generate_random_value(128)
-        logger.info('(%s) Generated RAND value: %s' % (
-            self.__address,
-            hexlify(self.__rand)
-        ))
+        logger.info("(%s) Generated RAND value: %s", self.__address, self.__rand.hex())
 
     @property
     def rand(self):
@@ -631,10 +627,7 @@ class SM_Peer(object):
         """
         if isinstance(value, bytes) and len(value) == 16:
             self.__rand = value
-            logger.debug('(%s) Set RAND value: %s' % (
-                self.__address,
-                hexlify(value)
-            ))
+            logger.debug("(%s) Set RAND value: %s", self.__address, value.hex())
         else:
             raise SMInvalidParameterFormat()
 
@@ -648,24 +641,15 @@ class SM_Peer(object):
         """
         if isinstance(value, bytes) and len(value) == 16:
             self.__confirm = value
-            logger.debug('(%s) Set confirm value: %s' % (
-                self.__address,
-                hexlify(value)
-            ))
+            logger.debug("(%s) Set confirm value: %s", self.__address, value.hex())
         else:
             raise SMInvalidParameterFormat()
 
     def check_peer_confirm(self, tk, preq, pres, peer, initiator=True):
         """Check peer confirm value
         """
-        logger.debug('(%s) RAND value: %s' % (
-            self.__address,
-            hexlify(self.__rand)
-        ))
-        logger.debug('(%s) CONFIRM value: %s' % (
-            self.__address,
-            hexlify(self.__confirm)
-        ))
+        logger.debug("(%s) RAND value: %s", self.__address, self.__rand.hex())
+        logger.debug("(%s) CONFIRM value: %s", self.__address, self.__confirm.hex())
         # First, compute confirm based on rand
         if initiator:
             _confirm = self.get_custom_function("compute_legacy_confirm_value")(
@@ -703,14 +687,8 @@ class SM_Peer(object):
             pack('<B', resp_addr_type),
             resp_addr[::-1]
         )
-        logger.info('(%s) Using RAND to compute confirm: %s' % (
-            self.__address,
-            hexlify(self.__rand)
-        ))
-        logger.info('(%s) Computed CONFIRM: %s' % (
-            self.__address,
-            hexlify(_confirm)
-        ))
+        logger.info("(%s) Using RAND to compute confirm: %s", self.__address, self.__rand.hex())
+        logger.info("(%s) Computed CONFIRM: %s", self.__address, _confirm.hex())
         return _confirm
 
 
@@ -928,7 +906,7 @@ class SMPLayer(Layer):
         :param SM_Peer initiator: Pairing initiator
         :param SM_Peer responder: Pairing responder
         """
-        logger.debug('[check_initiator_legacy_confirm] RAND=%s' % hexlify(self.state.initiator.rand))
+        logger.debug("[check_initiator_legacy_confirm] RAND=%s", self.state.initiator.rand.hex())
         # Compute expected confirm value
         expected_confirm = self.compute_legacy_confirm_value(
             tk,
@@ -938,8 +916,8 @@ class SMPLayer(Layer):
             self.state.initiator,
             self.state.responder
         )
-        logger.debug('[check_initiator_legacy_confirm] Computed CONFIRM=%s' % hexlify(expected_confirm))
-        logger.debug('[check_initiator_legacy_confirm] Expected CONFIRM=%s' % hexlify(self.state.initiator.confirm))
+        logger.debug("[check_initiator_legacy_confirm] Computed CONFIRM=%s", expected_confirm.hex())
+        logger.debug("[check_initiator_legacy_confirm] Expected CONFIRM=%s", self.state.initiator.confirm.hex())
 
         # Compare with confirm value
         return (expected_confirm == self.state.initiator.confirm)
@@ -954,7 +932,7 @@ class SMPLayer(Layer):
         :param SM_Peer initiator: Pairing initiator
         :param SM_Peer responder: Pairing responder
         """
-        logger.debug('[check_responder_legacy_confirm] RAND=%s' % hexlify(self.state.initiator.rand))
+        logger.debug("[check_responder_legacy_confirm] RAND=%s", self.state.initiator.rand.hex())
 
         # Compute expected confirm value
         expected_confirm = self.compute_legacy_confirm_value(
@@ -966,8 +944,8 @@ class SMPLayer(Layer):
             self.state.responder
         )
 
-        logger.debug('[check_initiator_legacy_confirm] Computed CONFIRM=%s' % hexlify(expected_confirm))
-        logger.debug('[check_initiator_legacy_confirm] Expected CONFIRM=%s' % hexlify(self.state.responder.confirm))
+        logger.debug("[check_initiator_legacy_confirm] Computed CONFIRM=%s", expected_confirm.hex())
+        logger.debug("[check_initiator_legacy_confirm] Expected CONFIRM=%s", self.state.responder.confirm.hex())
 
         # Compare with confirm value
         return (expected_confirm == self.state.responder.confirm)
@@ -1027,9 +1005,7 @@ class SMPLayer(Layer):
             random_number,
             r
         )
-        logger.info('Computed LESC CONFIRM: %s' % (
-            hexlify(_confirm)
-        ))
+        logger.info("Computed LESC CONFIRM: %s", _confirm.hex())
         return _confirm
 
     def compute_legacy_confirm_value(self, tk, rand, preq, pres, initiator, responder):
@@ -1048,16 +1024,17 @@ class SMPLayer(Layer):
         :return: Confirm value
         :rtype: bytes
         """
-        logger.debug('TK=%s RAND=%s, PRES=%s PREQ=%s INITA_TYPE=%02x INITA=%s RESPA_TYPE=%02x RESPA=%s' % (
-            hexlify(tk),
-            hexlify(rand),
-            hexlify(bytes(SM_Hdr()/pres)[::-1]),
-            hexlify(bytes(SM_Hdr()/preq)[::-1]),
+        logger.debug(
+            "TK=%s RAND=%s, PRES=%s PREQ=%s INITA_TYPE=%02x INITA=%s RESPA_TYPE=%02x RESPA=%s",
+            tk.hex(),
+            rand.hex(),
+            bytes(SM_Hdr()/pres)[::-1].hex(),
+            bytes(SM_Hdr()/preq)[::-1].hex(),
             initiator.address_type,
-            hexlify(initiator.address[::-1]),
+            initiator.address[::-1].hex(),
             responder.address_type,
-            hexlify(responder.address[::-1])
-        ))
+            responder.address[::-1].hex(),
+        )
 
         # Compute the confirm value for the provided parameters
         # We need to:
@@ -1319,7 +1296,7 @@ class SMPLayer(Layer):
                     b"\x00" # r equals 0 in JustWorks and NumComp
                 )
 
-                logger.debug('[send_pairing_confirm] Computed CONFIRM=%s' % hexlify(self.state.responder.confirm))
+                logger.debug("[send_pairing_confirm] Computed CONFIRM=%s", self.state.responder.confirm.hex())
 
                 # Update current state
                 self.state.state = SecurityManagerState.STATE_LESC_PAIRING_CONFIRM_SENT
@@ -1791,7 +1768,7 @@ class SMPLayer(Layer):
                     self.state.initiator,
                     self.state.responder
                 )
-                logger.debug('[send_pairing_confirm] Computed CONFIRM=%s' % hexlify(self.state.initiator.confirm))
+                logger.debug("[send_pairing_confirm] Computed CONFIRM=%s", self.state.initiator.confirm.hex())
 
                 # Send CONFIRM value (again, we need to reverse its bytes)
                 confirm_value = SM_Confirm(
@@ -1851,7 +1828,7 @@ class SMPLayer(Layer):
                 self.state.initiator,
                 self.state.responder
             )
-            logger.debug('[on_pairing_confirm] Computed CONFIRM=%s' % hexlify(self.state.responder.confirm))
+            logger.debug("[on_pairing_confirm] Computed CONFIRM=%s", self.state.responder.confirm.hex())
 
             # Send CONFIRM value (again, we need to reverse its bytes)
             confirm_value = SM_Confirm(
@@ -2113,7 +2090,7 @@ class SMPLayer(Layer):
                     self.state.initiator.rand
                 )
 
-                logger.debug('[on_pairing_random] STK=%s' % hexlify(self.state.stk))
+                logger.debug("[on_pairing_random] STK=%s", self.state.stk.hex())
 
                 # Notify connection that we successfully negociated STK and that
                 # the corresponding material is available.
@@ -2126,9 +2103,10 @@ class SMPLayer(Layer):
                 #self.__l2cap.connection.set_stk(self.state.stk)
 
             else:
-                logger.info('Invalid Initiator CONFIRM value (expected %s)' % (
-                    hexlify(self.state.initiator.confirm),
-                ))
+                logger.info(
+                    "Invalid Initiator CONFIRM value (expected %s)",
+                    self.state.initiator.confirm.hex(),
+                )
 
                 # Send error
                 error = SM_Failed(
@@ -2213,10 +2191,10 @@ class SMPLayer(Layer):
                     )
 
             else:
-
-                logger.info('Invalid responder CONFIRM value (expected %s)' % (
-                    hexlify(self.state.responder.confirm),
-                ))
+                logger.info(
+                    "Invalid responder CONFIRM value (expected %s)",
+                    self.state.responder.confirm.hex(),
+                )
 
                 # Send error
                 error = SM_Failed(
@@ -2256,10 +2234,10 @@ class SMPLayer(Layer):
                     )
                 )
             else:
-
-                logger.info('Invalid Initiator CONFIRM value (expected %s)' % (
-                    hexlify(self.state.initiator.confirm),
-                ))
+                logger.info(
+                    "Invalid Initiator CONFIRM value (expected %s)",
+                    self.state.initiator.confirm.hex(),
+                )
 
                 # Send error
                 error = SM_Failed(
@@ -2296,7 +2274,7 @@ class SMPLayer(Layer):
                 )
 
 
-                logger.debug('[on_pairing_random] STK=%s' % hexlify(self.state.stk))
+                logger.debug("[on_pairing_random] STK=%s", self.state.stk.hex())
 
                 # Next state
                 self.state.state = SecurityManagerState.STATE_LEGACY_PAIRING_RANDOM_RECVD
@@ -2311,9 +2289,10 @@ class SMPLayer(Layer):
                 self.get_layer('ll').start_encryption(conn_handle, 0, 0)
 
             else:
-                logger.info('Invalid Responder CONFIRM value (expected %s)' % (
-                    hexlify(self.state.responder.confirm),
-                ))
+                logger.info(
+                    "Invalid Responder CONFIRM value (expected %s)",
+                    self.state.responder.confirm.hex(),
+                )
 
                 # Send error
                 error = SM_Failed(

--- a/whad/ble/tools/proxy.py
+++ b/whad/ble/tools/proxy.py
@@ -10,7 +10,6 @@ read, write, notification and indication) between a client and the target
 device.
 """
 import logging
-from binascii import hexlify
 
 from scapy.layers.bluetooth4LE import BTLE_DATA
 from scapy.layers.bluetooth import L2CAP_Hdr
@@ -543,10 +542,7 @@ class LinkLayerProxy:
         :return: A PDU to be sent to the target device or None to avoid forwarding.
         :rtype: Packet, None
         """
-        logger.info("Received a Control PDU: %s (Direction: %d)",
-            hexlify(bytes(pdu)),
-            direction
-        )
+        logger.info("Received a Control PDU: %s (Direction: %d)", bytes(pdu).hex(), direction)
         return pdu
 
 
@@ -560,10 +556,7 @@ class LinkLayerProxy:
         :return: A PDU to be sent to the target device or None to avoid forwarding.
         :rtype: Packet, None
         """
-        logger.info("Received a Data PDU: %s (Direction: %d)",
-            hexlify(bytes(pdu)),
-            direction
-        )
+        logger.info("Received a Data PDU: %s (Direction: %d)", bytes(pdu).hex(), direction)
         return pdu
 
 

--- a/whad/ble/tools/proxy.py
+++ b/whad/ble/tools/proxy.py
@@ -150,12 +150,12 @@ class LowLevelPeripheral(Peripheral):
             logger.debug("Sending pending PDUs to other half...")
             for _pdu in self.__pending_data_pdus:
                 if self.__proxy is not None:
-                    logger.debug("Calling proxy on_data_pdu with PDU %s..." % _pdu)
+                    logger.debug("Calling proxy on_data_pdu with PDU %s...", _pdu)
                     pdu = self.__proxy.on_data_pdu(_pdu, BleDirection.SLAVE_TO_MASTER)
                     if pdu is not None:
                         self.send_pdu(reshape_pdu(pdu), self.__conn_handle, direction=BleDirection.SLAVE_TO_MASTER)
                 else:
-                    logger.debug("Directly sending PDU %s..." % _pdu)
+                    logger.debug("Directly sending PDU %s...", _pdu)
                     self.send_pdu(reshape_pdu(_pdu), self.__conn_handle)
 
 

--- a/whad/ble/utils/validators.py
+++ b/whad/ble/utils/validators.py
@@ -2,9 +2,6 @@
 """
 import re
 import argparse
-from typing import Tuple
-
-from binascii import unhexlify
 
 from whad.ble.profile.attribute import UUID, InvalidUUIDException as AttrInvalidUUIDException
 
@@ -250,7 +247,7 @@ def validate_int_att_handle(handle: int) -> int:
     return handle
 
 
-def validate_att_security_mode(mode: int, level: int) -> Tuple[int, int]:
+def validate_att_security_mode(mode: int, level: int) -> tuple[int, int]:
     """Validate ATT security mode.
 
     :param mode: Security mode to validate
@@ -313,8 +310,8 @@ def validate_ltk(ltk: str) -> str:
     """
     ltk = ltk.lower()
     try:
-        unhexlify(ltk)
-    except TypeError as err_type:
+        bytes.fromhex(ltk)
+    except ValueError as err_type:
         raise InvalidSMLTK(ltk) from err_type
     return ltk
 
@@ -332,8 +329,8 @@ def validate_irk(irk: str) -> str:
         irk = "00" * 16
     irk = irk.lower()
     try:
-        unhexlify(irk)
-    except TypeError as err_type:
+        bytes.fromhex(irk)
+    except ValueError as err_type:
         raise InvalidSMIRK(irk) from err_type
     return irk
 
@@ -351,8 +348,8 @@ def validate_csrk(csrk: str) -> str:
         csrk = "00" * 16
     csrk = csrk.lower()
     try:
-        unhexlify(csrk)
-    except TypeError as err_type:
+        bytes.fromhex(csrk)
+    except ValueError as err_type:
         raise InvalidSMCSRK(csrk) from err_type
     return csrk
 
@@ -368,7 +365,7 @@ def validate_rand(rand):
     """
     rand = rand.lower()
     try:
-        unhexlify(rand)
-    except TypeError as err_type:
+        bytes.fromhex(rand)
+    except ValueError as err_type:
         raise InvalidSMRandom(rand) from err_type
     return rand

--- a/whad/cli/app.py
+++ b/whad/cli/app.py
@@ -610,10 +610,10 @@ class CommandLineApp(ArgumentParser):
                 pid = os.getpid()
                 stdout_target = os.readlink(f"/proc/{pid}/fd/1")
                 if stdout_target != "/dev/null":
-                    logger.debug(f"[cli] stdout is redirected to {stdout_target}")
+                    logger.debug("[cli] stdout is redirected to %s", stdout_target)
                     return True
                 else:
-                    logger.debug(f"[cli] stdout redirected to /dev/null, no unix socket needed")
+                    logger.debug("[cli] stdout redirected to /dev/null, no unix socket needed")
                     return False
             else:
                 logger.debug("[cli] stdout is redirected and cannot determine if it leads to /dev/null or not (OS not Linux)")

--- a/whad/common/monitors/pcap.py
+++ b/whad/common/monitors/pcap.py
@@ -55,11 +55,11 @@ class PcapWriterMonitor(WhadMonitor):
         if existing_pcap_file:
             # Checks if it is a named FIFO
             if S_ISFIFO(stat(self._pcap_file).st_mode):
-                logger.info("[i] Named pipe %s detected, syncing." % self._pcap_file)
+                logger.info("[i] Named pipe %s detected, syncing.", self._pcap_file)
                 sync = True
             else:
                 # Checks if it is an already existing pcap file.
-                logger.info("[i] PCAP file %s exists, appending new packets."  % self._pcap_file)
+                logger.info("[i] PCAP file %s exists, appending new packets.", self._pcap_file)
                 try:
                     # We collect the first packet timestamp to use it as reference time
                     self._start_time = PcapReader(self._pcap_file).read_packet().time * 1000000

--- a/whad/device/connector.py
+++ b/whad/device/connector.py
@@ -315,7 +315,7 @@ class WhadDeviceConnector:
         :param  Packet pdu:  Packet to add to locked packets queue
         :type   pdu: scapy.packet.Packet
         """
-        logger.info("Add locked pdu: %s" % pdu)
+        logger.info("Add locked pdu: %s", pdu)
         self.__locked_pdus.put(pdu)
 
     # Device interaction

--- a/whad/device/device.py
+++ b/whad/device/device.py
@@ -6,7 +6,6 @@ including background threads.
 """
 import logging
 import struct
-from binascii import hexlify
 from time import time, sleep
 from queue import Queue, Empty
 from threading import Thread, Lock
@@ -709,8 +708,7 @@ class WhadDevice:
         :param bytes data: Data received from the device.
         """
         #logger.info("[WhadDevice] entering on_data_received()")
-        logger.debug("[WhadDevice] received raw data from device <%s>: %s",
-                     self.interface, hexlify(data))
+        logger.debug("[WhadDevice] received raw data from device <%s>: %s", self.interface, data.hex())
         self.__inpipe.extend(data)
         while len(self.__inpipe) > 2:
             # Is the magic correct ?

--- a/whad/device/tcp.py
+++ b/whad/device/tcp.py
@@ -11,7 +11,6 @@ import logging
 import socket
 import select
 import re
-from binascii import hexlify
 from ipaddress import ip_address
 
 from whad.device import WhadDevice, WhadDeviceConnector
@@ -170,7 +169,7 @@ class TCPSocketDevice(WhadDevice):
         :param bytes data: Data to write
         :returns: number of bytes written to the device
         """
-        logger.debug("sending data to TCP socket: %s", hexlify(data))
+        logger.debug("sending data to TCP socket: %s", data.hex())
         if not self.__opened:
             raise WhadDeviceNotReady()
 
@@ -267,7 +266,7 @@ class TCPSocketConnector(WhadDeviceConnector):
         :param data: Incoming data
         :type data: bytes
         """
-        logger.debug("received raw data from socket: %s", hexlify(data))
+        logger.debug("received raw data from socket: %s", data.hex())
         self.__inpipe.extend(data)
         while len(self.__inpipe) > 2:
             # Is the magic correct ?

--- a/whad/device/unix.py
+++ b/whad/device/unix.py
@@ -16,7 +16,6 @@ import re
 import logging
 from threading import Thread
 from random import randint
-from binascii import hexlify
 
 from scapy.config import conf
 
@@ -131,7 +130,7 @@ class UnixSocketDevice(WhadDevice):
         :param bytes data: Data to write
         :returns: number of bytes written to the device
         """
-        logger.debug("sending data to unix socket: %s", hexlify(data))
+        logger.debug("sending data to unix socket: %s", data.hex())
         if not self.__opened:
             raise WhadDeviceNotReady()
 
@@ -377,7 +376,7 @@ class UnixSocketServerDevice(WhadDevice):
         :param bytes data: Data to write
         :returns: number of bytes written to the device
         """
-        logger.debug("sending data to unix server client socket: %s", hexlify(data))
+        logger.debug("sending data to unix server client socket: %s", data.hex())
         if not self.__opened:
             raise WhadDeviceNotReady()
 
@@ -551,7 +550,7 @@ class UnixSocketConnector(WhadDeviceConnector):
     def on_data_received(self, data):
         """Handle received data from the unix socket.
         """
-        logger.debug("received raw data from socket: %s", hexlify(data))
+        logger.debug("received raw data from socket: %s", data.hex())
         self.__inpipe.extend(data)
         while len(self.__inpipe) > 2:
             # Is the magic correct ?

--- a/whad/device/websocket.py
+++ b/whad/device/websocket.py
@@ -12,7 +12,6 @@ from whad.common.converters.scapy import ScapyConverter
 from websockets.sync.server import serve
 from websockets.exceptions import ConnectionClosedOK
 from time import sleep
-from binascii import hexlify
 
 import threading
 import logging
@@ -65,7 +64,7 @@ class WebSocketConnector(WhadDeviceConnector):
         :param data: Incoming data
         :type data: bytes
         """
-        logger.debug("received raw data from socket: %s", hexlify(data))
+        logger.debug("received raw data from socket: %s", data)
         self.__inpipe.extend(data)
         while len(self.__inpipe) > 2:
             # Is the magic correct ?

--- a/whad/dot15d4/address.py
+++ b/whad/dot15d4/address.py
@@ -1,5 +1,4 @@
 import re
-from binascii import hexlify, unhexlify
 from whad.dot15d4.exceptions import InvalidDot15d4AddressException
 from struct import pack, unpack
 
@@ -19,16 +18,16 @@ class Dot15d4Address(object):
         if isinstance(address, str):
             if re.match(r'^([0-9a-fA-F]{2}\:){7}[0-9a-fA-F]{2}$', address) is not None:
                 self.__type = Dot15d4Address.EXTENDED
-                self.__value = unhexlify(address.replace(':',''))
+                self.__value = bytes.fromhex(address.replace(":", ""))
             elif re.match('[0-9a-fA-F]{16}$', address) is not None:
                 self.__type = Dot15d4Address.EXTENDED
-                self.__value = unhexlify(address)
+                self.__value = bytes.fromhex(address)
             elif re.match('[0-9a-fA-F]{4}$', address) is not None:
                 self.__type = Dot15d4Address.SHORT
-                self.__value = unhexlify(address)
+                self.__value = bytes.fromhex(address)
             elif re.match('0x[0-9a-fA-F]{4}$', address) is not None:
                 self.__type = Dot15d4Address.SHORT
-                self.__value = unhexlify(address[2:])
+                self.__value = bytes.fromhex(address[2:])
             else:
                 raise InvalidDot15d4AddressException
         elif isinstance(address, int):
@@ -42,12 +41,10 @@ class Dot15d4Address(object):
             raise InvalidDot15d4AddressException
 
     def __eq__(self, other):
-
         if not isinstance(other, Dot15d4Address):
             other = Dot15d4Address(other)
 
         return (self.value == other.value) and (self.__type == other.type)
-
 
     def __str__(self):
         if self.__type == Dot15d4Address.EXTENDED:
@@ -77,7 +74,6 @@ class Dot15d4Address(object):
         """
         return (self.__type == Dot15d4Address.EXTENDED)
 
-
     @staticmethod
     def from_bytes(addr_bytes):
         """Convert a 2 or 8-byte array into a valid 802.15.4 address.
@@ -86,12 +82,12 @@ class Dot15d4Address(object):
         :rtype: Dot15d4Address
         :return: An instance of Dot15d4Address representing the corresponding Dot15d4 address.
         """
+        hex_address = addr_bytes[::-1].hex()
         if len(addr_bytes) == 8:
-            hex_address = hexlify(addr_bytes[::-1])
-            address = b':'.join([hex_address[i*2:(i+1)*2] for i in range(int(len(hex_address)/2))])
-            return Dot15d4Address(address.decode('utf-8'))
+            address = ":".join([hex_address[i*2:(i+1)*2] for i in range(int(len(hex_address)/2))])
+            return Dot15d4Address(address)
         elif len(addr_bytes) == 2:
-            address = b''.join([hex_address[i*2:(i+1)*2] for i in range(int(len(hex_address)/2))])
-            return Dot15d4Address(address.decode('utf-8'))
+            address = "".join([hex_address[i*2:(i+1)*2] for i in range(int(len(hex_address)/2))])
+            return Dot15d4Address(address)
         else:
             raise InvalidDot15d4AddressException

--- a/whad/dot15d4/stack/__init__.py
+++ b/whad/dot15d4/stack/__init__.py
@@ -48,7 +48,7 @@ class Dot15d4Stack(Layer):
 
         This callback handles a PDU and forwards it to MAC layer.
         '''
-        logger.debug('received a PDU (%d bytes)' % (len(pdu)))
+        logger.debug("received a PDU (%d bytes)", len(pdu))
         self.send('mac', pdu, tag='pdu')
 
     def on_ed_sample(self, timestamp, sample):
@@ -56,7 +56,7 @@ class Dot15d4Stack(Layer):
 
         This callback handle an Energy Detection sample and forwards it to MAC layer.
         '''
-        logger.debug('received an energy detection sample (%d / timestamp=%d) ' % (sample, timestamp))
+        logger.debug("received an energy detection sample (%d / timestamp=%d) ", sample, timestamp)
 
         # Notify link layer we received a control PDU for a given `conn_handle`.
         self.send('mac', sample, tag='energy_detection', timestamp=timestamp)

--- a/whad/dot15d4/stack/mac/__init__.py
+++ b/whad/dot15d4/stack/mac/__init__.py
@@ -873,7 +873,7 @@ class MACManager(Dot15d4Manager):
             elif pdu.fcf_frametype == 0x00 or Dot15d4Beacon in pdu:
                 self.get_service("management").on_beacon_pdu(pdu)
             else:
-                logger.warning("[mac_manager] Malformed PDU received: {}".format(repr(pdu)))
+                logger.warning("[mac_manager] Malformed PDU received: %s", repr(pdu))
 
     def match_filter(self, pdu):
         macPromiscuousMode = self.database.get("macPromiscuousMode")

--- a/whad/dot15d4/stack/service.py
+++ b/whad/dot15d4/stack/service.py
@@ -77,9 +77,9 @@ class Dot15d4Service:
             @wraps(func)
             def request_decorator(*args, **kwargs):
                 self = args[0]
-                self._logger.info("[{}] {} request ({},{})".format(args[0]._name, request_name, str(args[1:]),str(kwargs)))
+                self._logger.info("[%s] %s request (%s,%s)", args[0]._name, request_name, str(args[1:]),str(kwargs))
                 result = func(*args, **kwargs)
-                self._logger.info("[{}] {} confirm ({})".format(args[0]._name, request_name, str(result)))
+                self._logger.info("[%s] %s confirm (%s)", args[0]._name, request_name, str(result))
                 return result
             return request_decorator
         return _request
@@ -92,7 +92,7 @@ class Dot15d4Service:
             @wraps(func)
             def response_decorator(*args, **kwargs):
                 self = args[0]
-                self._logger.info("[{}] {} response ({},{})".format(args[0]._name, response_name, str(args[1:]),str(kwargs)))
+                self._logger.info("[%s] %s response (%s,%s)", args[0]._name, response_name, str(args[1:]),str(kwargs))
                 result = func(*args, **kwargs)
                 return result
             return response_decorator
@@ -109,14 +109,14 @@ class Dot15d4Service:
                 pdu, parameters = func(*args, **kwargs)
 
                 if self._manager.upper_layer is None:
-                    self._logger.warning("[{}] {} indication not transmitted, no upper layer !".format(self._name, indication_name))
+                    self._logger.warning("[%s] %s indication not transmitted, no upper layer !", self._name, indication_name)
                     return None
 
                 upper = self._manager.upper_layer.alias
                 callback_kwargs = {"tag":indication_name}
                 callback_kwargs.update(parameters)
 
-                self._logger.info("[{}] {} indication ({},{})".format(self._name, indication_name, str(pdu), str(callback_kwargs)))
+                self._logger.info("[%s] %s indication (%s,%s)", self._name, indication_name, str(pdu), str(callback_kwargs))
                 return_value = self._manager.send(upper, pdu, **callback_kwargs)
                 return return_value
 

--- a/whad/esb/esbaddr.py
+++ b/whad/esb/esbaddr.py
@@ -5,7 +5,6 @@ This module provides the `ESBAddress` class that represents
 an Enhanced ShockBurst device address.
 """
 import re
-from binascii import hexlify, unhexlify
 from whad.esb.exceptions import InvalidESBAddressException
 
 class ESBAddress:
@@ -17,9 +16,9 @@ class ESBAddress:
         """
         if isinstance(address, str):
             if re.match(r'^([0-9a-fA-F]{2}\:){4}[0-9a-fA-F]{2}$', address) is not None:
-                self.__value = unhexlify(address.replace(':',''))
+                self.__value = bytes.fromhex(address.replace(":",""))
             elif re.match('[0-9a-fA-F]{10}$', address) is not None:
-                self.__value = unhexlify(address)
+                self.__value = bytes.fromhex(address)
             else:
                 raise InvalidESBAddressException
         elif isinstance(address, bytes) and len(address) > 1 and len(address) <= 5:
@@ -72,9 +71,9 @@ class ESBAddress:
         :return: An instance of ESBAddress representing the corresponding ESB address.
         """
         if len(esb_addr_bytes) == 5:
-            hex_address = hexlify(esb_addr_bytes)
-            address = b":".join([hex_address[i*2:(i+1)*2] for i in range(int(len(hex_address)/2))])
-            return ESBAddress(address.decode("utf-8"))
+            hex_address = esb_addr_bytes.hex()
+            address = ":".join([hex_address[i*2:(i+1)*2] for i in range(int(len(hex_address)/2))])
+            return ESBAddress(address)
 
         # Raise an error (invalid address size)
         raise InvalidESBAddressException

--- a/whad/lorawan/app.py
+++ b/whad/lorawan/app.py
@@ -219,7 +219,7 @@ class LWNodeRegistry(object):
                 raise InvalidNodeRegistryError(path)
             except Exception:
                 # Oops, error while loading registry. Unlink file.
-                logger.error('Error while loading registry file %s, removing file.' % path)
+                logger.error("Error while loading registry file %s, removing file.", path)
                 unlink(path)
         else:
             # File does not exist, create it.
@@ -235,12 +235,10 @@ class LWNodeRegistry(object):
         :type node: LWNode
         """
         if node.dev_eui in self.__nodes:
-            logger.warning('Device %s is already present in node registry' % (
-                node.dev_eui
-            ))
+            logger.warning("Device %s is already present in node registry", node.dev_eui)
             self.__nodes[node.dev_eui] = node
         else:
-            logger.debug('adding node %s' % node)
+            logger.debug("adding node %s", node)
             self.__nodes[node.dev_eui] = node
 
     def get_node(self, eui:str = None) -> LWNode:

--- a/whad/lorawan/app.py
+++ b/whad/lorawan/app.py
@@ -15,7 +15,6 @@ import sys
 import json
 from os import unlink
 from os.path import exists, isfile
-from binascii import hexlify, unhexlify
 
 # Including type hint Iterator based on python version
 if sys.version_info[0] == 3 and sys.version_info[1] >= 9:
@@ -59,8 +58,8 @@ class LWNode(object):
         return 'LWNode(eui:%s, address:%s, appskey:%s, nwkskey:%s, uplink_count:%d, downlink_count:%d)' % (
             self.dev_eui,
             self.dev_addr,
-            hexlify(self.__appskey).decode('ascii') if self.__appskey is not None else None,
-            hexlify(self.__nwkskey).decode('ascii') if self.__nwkskey is not None else None,
+            self.__appskey.hex() if self.__appskey is not None else None,
+            self.__nwkskey.hex() if self.__nwkskey is not None else None,
             self.__upcount,
             self.__dncount
         )
@@ -162,8 +161,8 @@ class LWNode(object):
         return {
             'dev_eui': self.dev_eui,
             'dev_addr': self.dev_addr,
-            'appskey': hexlify(self.appskey).decode('ascii'),
-            'nwkskey': hexlify(self.nwkskey).decode('ascii'),
+            'appskey': self.appskey.hex(),
+            'nwkskey': self.nwkskey.hex(),
             'upcount': self.upcount,
             'dncount': self.dncount
         }
@@ -178,12 +177,12 @@ class LWNode(object):
         :rtype: LWNode
         """
         return LWNode(
-            data['dev_eui'],
-            data['dev_addr'],
-            unhexlify(data['appskey']),
-            unhexlify(data['nwkskey']),
-            data['upcount'],
-            data['dncount']
+            data["dev_eui"],
+            data["dev_addr"],
+            bytes.fromhex(data["appskey"]),
+            bytes.fromhex(data["nwkskey"]),
+            data["upcount"],
+            data["dncount"]
         )
     
 
@@ -216,9 +215,9 @@ class LWNodeRegistry(object):
                         node_ = LWNode.fromJSON(node)
                         self.__nodes[node_.dev_eui] = node_
                     registry.close()
-            except IOError as file_err:
+            except IOError:
                 raise InvalidNodeRegistryError(path)
-            except Exception as other_err:
+            except Exception:
                 # Oops, error while loading registry. Unlink file.
                 logger.error('Error while loading registry file %s, removing file.' % path)
                 unlink(path)
@@ -226,9 +225,9 @@ class LWNodeRegistry(object):
             # File does not exist, create it.
             try:
                 self.save()
-            except IOError as file_err:
+            except IOError:
                 raise InvalidNodeRegistryError(path)
-            
+
     def add_node(self, node: LWNode):
         """Register a LoRaWAN node.
 
@@ -273,7 +272,7 @@ class LWNodeRegistry(object):
                     nodes.append(self.__nodes[node_eui].toDict())
                 json.dump(nodes, registry)
                 registry.close()
-        except IOError as file_err:
+        except IOError:
             raise InvalidNodeRegistryError(self.__path)
 
     

--- a/whad/lorawan/connector/__init__.py
+++ b/whad/lorawan/connector/__init__.py
@@ -44,7 +44,7 @@ class LoRaWAN(LoRa):
         super().__init__(device)
 
         # Configure channel plan
-        logger.debug('Channel plan set to %s' % channel_plan.__name__)
+        logger.debug("Channel plan set to %s", channel_plan.__name__)
         self.__channel_plan = channel_plan()
         self.__pkt_queue = Queue()
         self.__cr = 45
@@ -65,7 +65,7 @@ class LoRaWAN(LoRa):
         :param invert_iq: Invert IQ if set to `True`
         :type invert_iq: bool, optional
         '''
-        logger.debug('Reconfiguring hardware for channel %s' % channel)
+        logger.debug("Reconfiguring hardware for channel %s", channel)
 
         # Reconfigure hardware (stop if necessary, then restart if we were already started)
         must_restart = self.__started
@@ -80,10 +80,10 @@ class LoRaWAN(LoRa):
         self.bw = channel.bandwidth
         self.preamble_length = 8
         self.invert_iq = invert_iq
-        logger.debug('Enabling CRC: %s' % crc)
+        logger.debug("Enabling CRC: %s", crc)
         self.enable_crc(crc)
         self.enable_explicit_mode(True)
-        logger.debug('Setting Freq: %d' % channel.frequency)
+        logger.debug("Setting Freq: %d", channel.frequency)
         self.set_frequency(channel.frequency)
         self.syncword = LoRa.SYNCWORD_LORAWAN
 
@@ -101,7 +101,7 @@ class LoRaWAN(LoRa):
         '''
         self.__current_channel = self.__channel_plan.pick_channel()
         self.reconfigure(self.__current_channel)
-        logger.debug('TX channel: %s' % self.__current_channel)
+        logger.debug("TX channel: %s", self.__current_channel)
 
     def rx1(self):
         '''Configure hardware to listen on RX1.
@@ -110,7 +110,7 @@ class LoRaWAN(LoRa):
         '''
         # Retrieve RX1 channel modulation parameters from channel plan
         rx1_channel = self.__channel_plan.get_rx1(self.__current_channel.number)
-        logger.debug('RX1 channel: %s' % rx1_channel)
+        logger.debug("RX1 channel: %s", rx1_channel)
 
         # Change hardware configuration only if needed
         if rx1_channel != self.__current_channel or self.crc_enabled:
@@ -123,7 +123,7 @@ class LoRaWAN(LoRa):
         parameters used as a backup channel for downlink communication.
         '''
         rx2_channel = self.__channel_plan.get_rx2()
-        logger.debug('RX2 channel: %s' % rx2_channel)
+        logger.debug("RX2 channel: %s", rx2_channel)
 
         # Change hardware configuration only if needed
         if rx2_channel != self.__current_channel or self.crc_enabled:
@@ -226,7 +226,7 @@ class LoRaWAN(LoRa):
                 # Return JoinAccept if MIC is OK
                 return resp
             else:
-                logger.debug('MIC does not match (expected: %s)' % exp_mic)
+                logger.debug("MIC does not match (expected: %s)", exp_mic)
                 return None
 
     def join(self, app_key : bytes, app_eui : str, dev_eui : str, dev_nonce : int):
@@ -243,11 +243,12 @@ class LoRaWAN(LoRa):
         :param dev_nonce: Device nonce
         :type dev_nonce: str
         '''
-        logger.debug('Building a join request for APPEUI %s, DEVEUI %s' % (
+        logger.debug(
+            "Building a join request for APPEUI %s, DEVEUI %s",
             app_eui,
-            dev_eui
-        ))
-        logger.debug('Using DevNonce=0x%04x' % dev_nonce)
+            dev_eui,
+        )
+        logger.debug("Using DevNonce=0x%04x", dev_nonce)
 
         join_req = Join_Request()
         join_req.AppEUI = eui_to_bytes(app_eui)

--- a/whad/lorawan/connector/gateway.py
+++ b/whad/lorawan/connector/gateway.py
@@ -1,5 +1,3 @@
-from binascii import hexlify
-
 from whad.device import WhadDevice
 from whad.lorawan.stack import LWGatewayStack
 from whad.scapy.layers.lorawan import PHYPayload
@@ -123,10 +121,7 @@ class LWGateway(LoRaWAN):
         :return: Data to be sent back to the device
         :rtype: bytes
         """
-        logger.info('[gateway] Device %s sent data: %s' % (
-            dev_eui,
-            hexlify(data)
-        ))
+        logger.info("[gateway] Device %s sent data: %s", dev_eui, data.hex())
         return self.__app.on_device_data(
             dev_eui,
             dev_addr,

--- a/whad/lorawan/connector/gateway.py
+++ b/whad/lorawan/connector/gateway.py
@@ -94,10 +94,11 @@ class LWGateway(LoRaWAN):
         :param nwkskey: Device network encryption session key
         :type nwkske: bytes
         """
-        logger.info('[gateway] Device %s joined network with address 0x%08x' % (
+        logger.info(
+            "[gateway] Device %s joined network with address 0x%08x",
             dev_eui,
             dev_addr,
-        ))
+        )
 
         self.__app.on_device_joined(
             dev_eui,

--- a/whad/lorawan/stack/__init__.py
+++ b/whad/lorawan/stack/__init__.py
@@ -111,7 +111,7 @@ class LWGatewayStack(Layer):
         :type timestamp: float
         """
         # Switch to RX1
-        logger.debug('[phy] sending frame of %d bytes' % len(bytes(frame)))
+        logger.debug("[phy] sending frame of %d bytes", len(bytes(frame)))
         self.__connector.rx1()
         self.__connector.send(bytes(frame), timestamp=timestamp)
         

--- a/whad/lorawan/stack/__init__.py
+++ b/whad/lorawan/stack/__init__.py
@@ -1,7 +1,6 @@
 """
 Pythonic LoRaWAN 1.0 stack
 """
-from binascii import unhexlify
 from whad.scapy.layers.lorawan import PHYPayload
 from whad.lorawan.stack.llm import LWGwLinkLayer
 from whad.lorawan.helpers import EUI
@@ -20,7 +19,7 @@ class LWGatewayState(LayerState):
         super().__init__()
 
         # Set APPKey to default value
-        self.appkey = unhexlify('00000000000000000000000000000000')
+        self.appkey = bytes.fromhex("00000000000000000000000000000000")
         self.appeui = EUI('01:02:03:04:05:06:07:08')
 
 
@@ -50,7 +49,7 @@ class LWGatewayStack(Layer):
 
         # APPKey must be provided
         if 'appkey' in options:
-            self.state.appkey = unhexlify(options['appkey'])
+            self.state.appkey = bytes.fromhex(options["appkey"])
 
         # APP EUI too
         if 'appeui' in options:

--- a/whad/lorawan/stack/llm.py
+++ b/whad/lorawan/stack/llm.py
@@ -169,10 +169,11 @@ class LWGwLinkLayer(Layer):
             if app_eui == self.app_eui and self.get_layer('phy').is_device_allowed(dev_eui):
 
                 # Device is allowed and application is known
-                logger.debug('Device with EUI %s is allowed to join with app EUI %s' % (
+                logger.debug(
+                    "Device with EUI %s is allowed to join with app EUI %s",
                     dev_eui,
-                    app_eui
-                ))
+                    app_eui,
+                )
 
                 # Add node to our list of connections
                 dev_addr = self.generate_devaddr()
@@ -216,21 +217,23 @@ class LWGwLinkLayer(Layer):
 
                 # Send response
                 ts = frame.metadata.timestamp/1000000.
-                logger.debug('JoinRequest timestamp: %f' % ts)
-                logger.debug('will send JoinAccept at %f' % (ts + self.state.join_delay1))
+                logger.debug("JoinRequest timestamp: %f", ts)
+                logger.debug("will send JoinAccept at %f", ts + self.state.join_delay1)
                 self.send('phy', enc_ja, timestamp=ts + self.state.join_delay1)
                 sleep(self.state.join_delay1 + 0.5)
             else:
                 if app_eui != self.app_eui:
-                    logger.debug('Application %s is requested, expected application EUI %s' % (
+                    logger.debug(
+                        "Application %s is requested, expected application EUI %s",
                         app_eui,
-                        self.app_eui
-                    ))
+                        self.app_eui,
+                    )
                 else:
-                    logger.debug('Device with EUI %s is not allowed to access application EUI %s' % (
+                    logger.debug(
+                        "Device with EUI %s is not allowed to access application EUI %s",
                         dev_eui,
-                        app_eui
-                    ))
+                        app_eui,
+                    )
         else:
             logger.debug(
                 'JoinRequest MIC is wrong (got %s instead of %s)' % (
@@ -251,14 +254,16 @@ class LWGwLinkLayer(Layer):
         :param dev_nwkskey: Device network encryption session key
         :type dev_nwkskey: bytes
         """
-        logger.debug('add a pre-provisioned device (address 0x%08x, eui: %s)' % (
-            dev_addr, dev_eui
-        ))
+        logger.debug(
+            "add a pre-provisioned device (address 0x%08x, eui: %s)",
+            dev_addr,
+            dev_eui,
+        )
 
         # Instantiate a node for our connection
         conn_mac = self.instantiate(LWMacLayer)
         conn_mac.set_devaddr(dev_addr)
-        logger.debug('created a LWMACLayer instance for device: %s' % conn_mac.name)
+        logger.debug("created a LWMACLayer instance for device: %s", conn_mac.name)
 
         # Set uplink/downlink frame counters
         conn_mac.set_up_counter(upcount)
@@ -313,7 +318,7 @@ class LWGwLinkLayer(Layer):
                 confirmed=False
             )
         else:
-            logger.debug('Device address 0x%08x is not known' % mac_layer.dev_addr)
+            logger.debug("Device address 0x%08x is not known", mac_layer.dev_addr)
 
     def on_confirmed_data_up(self, conf_data_up : PHYPayload):
         """Process a confirmed data up.
@@ -360,9 +365,11 @@ class LWGwLinkLayer(Layer):
         # Find node from instance name
         connection = self.state.get_connection_from_node(inst_name)
         if connection is not None:
-            logger.debug('[llm] MAC instance %s resolved to device eui %s' % (
-                inst_name, connection['dev_eui']
-            ))
+            logger.debug(
+                "[llm] MAC instance %s resolved to device eui %s",
+                inst_name,
+                connection['dev_eui'],
+            )
 
             # Craft downlink frame
             packet = PHYPayload()/frame
@@ -386,7 +393,7 @@ class LWGwLinkLayer(Layer):
             )
             sleep(self.state.rx_delay1 + 0.5)
         else:
-            logger.debug('[llm] MAC instance %s not found' % inst_name)
+            logger.debug("[llm] MAC instance %s not found", inst_name)
 
     def on_data_received(self, dev_addr : int, data : bytes, upcount : int = 0):
         """Report data reception to phy
@@ -408,5 +415,5 @@ class LWGwLinkLayer(Layer):
                 upcount
             )
         else:
-            logger.debug('[llm][on_data_received] Device address 0x%08x not found' % dev_addr)
+            logger.debug("[llm][on_data_received] Device address 0x%08x not found", dev_addr)
             return None

--- a/whad/lorawan/stack/llm.py
+++ b/whad/lorawan/stack/llm.py
@@ -2,7 +2,6 @@
 LoRaWAN Gateway stack link-layer manager
 """
 from time import sleep, time
-from binascii import hexlify
 from random import randint
 from whad.lorawan.stack.mac import LWMacLayer
 from whad.common.stack import LayerState, Layer, alias, source, state,instance
@@ -235,8 +234,8 @@ class LWGwLinkLayer(Layer):
         else:
             logger.debug(
                 'JoinRequest MIC is wrong (got %s instead of %s)' % (
-                hexlify(bytes(frame)[-4:]),
-                hexlify(exp_mic)
+                bytes(frame)[-4:].hex(),
+                exp_mic.hex()
             ))
 
     def add_provisioned_device(self, dev_addr : int, dev_eui : str, appskey : bytes,

--- a/whad/phy/cli/inspect.py
+++ b/whad/phy/cli/inspect.py
@@ -12,7 +12,6 @@ This tool is meant to be completely PHY agnostic and will work with any hardware
 Guessed configuration can be saved for later use, in a dedicated configuration file.
 """
 from time import sleep
-from binascii import hexlify
 from queue import Queue, Empty
 from whad.cli.app import CommandLineApp, ApplicationError
 from whad.phy.connector import Phy
@@ -42,7 +41,7 @@ class PhyCorrelator(Phy):
         into our RX queue and wait for the queue to be read later.
         """
         if packet.metadata.rssi > self.__rssi:
-            print(hexlify(bytes(packet)))
+            print(bytes(packet).hex())
             if self.__callback is not None:
                 self.__callback(packet)
             else:

--- a/whad/unifying/stack/__init__.py
+++ b/whad/unifying/stack/__init__.py
@@ -424,7 +424,7 @@ class UnifyingApplicativeLayer(Layer):
 
     @dongle_callback
     def on_wakeup(self, dev_index):
-        logger.info("Waked up by device (dev_index=0x{:02x})".format(dev_index))
+        logger.info("Waked up by device (dev_index=0x%02x)", dev_index)
 
     @dongle_callback
     def on_set_keepalive(self, timeout):

--- a/whad/zigbee/stack/apl/__init__.py
+++ b/whad/zigbee/stack/apl/__init__.py
@@ -232,7 +232,7 @@ class APLManager(Dot15d4Manager):
         )
         # If cluster has not been found in the corresponding application, display an error
         if not success:
-            logger.info("[apl] cluster not found (cluster_id=0x{:04x}).".format(cluster_id))
+            logger.info("[apl] cluster not found (cluster_id=0x%04x).", cluster_id)
 
     @source('aps', "APSME-JOIN")
     def on_join(

--- a/whad/zigbee/stack/apl/zcl/__init__.py
+++ b/whad/zigbee/stack/apl/zcl/__init__.py
@@ -316,12 +316,13 @@ class ZCLCluster(Cluster, metaclass=ZCLClusterMetaclass):
         if not found_calling_callback:
             return False
 
-        logger.info("[zcl] Cluster {} (cluster_id={}) Transmitting {} command '{}' (command_id={})".format(
+        logger.info(
+            "[zcl] Cluster %s (cluster_id=%s) Transmitting %s command '%s' (command_id=%s)",
             self.__class__.__name__,
             hex(self.cluster_id),
             "cluster specific" if cluster_specific else "profile wide",
             command_structure.name,
-            hex(command_id))
+            hex(command_id),
         )
         # Get the current configuration
         current_configuration = self.configuration
@@ -452,12 +453,13 @@ class ZCLCluster(Cluster, metaclass=ZCLClusterMetaclass):
                     elif name in ("no_response", "disable_default_response"):
                         parameters += [asdu[base_class].disable_default_response]
 
-            logger.info("[zcl] Cluster {} (cluster_id={}) Receiving {} interpan command '{}' (command_id={})".format(
+            logger.info(
+                "[zcl] Cluster %s (cluster_id=%s) Receiving %s interpan command '%s' (command_id=%s)",
                 self.__class__.__name__,
                 hex(self.cluster_id),
                 "cluster specific" if asdu.zcl_frametype == 1 else "profile wide",
                 command.name,
-                hex(command_identifier))
+                hex(command_identifier),
             )
             # Call reception callback and update the pending response dict with the return value
             return_value = command.receive_callback(*parameters)
@@ -465,7 +467,7 @@ class ZCLCluster(Cluster, metaclass=ZCLClusterMetaclass):
                 self.pending_responses[asdu.transaction_sequence] = return_value
 
         except ZCLCommandNotFound:
-            logger.info("[zcl] command not found (command_identifier = 0x{:02x})".format(command_identifier))
+            logger.info("[zcl] command not found (command_identifier = 0x%02x)", command_identifier)
 
 
     def on_data(self, asdu, source_address, source_address_mode, security_status, link_quality):
@@ -507,12 +509,13 @@ class ZCLCluster(Cluster, metaclass=ZCLClusterMetaclass):
                     elif name in ("no_response", "disable_default_response"):
                         parameters += [asdu[ZigbeeClusterLibrary].disable_default_response]
 
-            logger.info("[zcl] Cluster {} (cluster_id={}) Receiving {} command '{}' (command_id={})".format(
+            logger.info(
+                "[zcl] Cluster %s (cluster_id=%s) Receiving %s command '%s' (command_id=%s)",
                 self.__class__.__name__,
                 hex(self.cluster_id),
                 "cluster specific" if asdu.zcl_frametype == 1 else "profile wide",
                 command.name,
-                hex(command_identifier))
+                hex(command_identifier),
             )
             # Call reception callback and update the pending response dict with the return value
             return_value = command.receive_callback(*parameters)
@@ -520,7 +523,7 @@ class ZCLCluster(Cluster, metaclass=ZCLClusterMetaclass):
                 self.pending_responses[asdu.transaction_sequence] = return_value
 
         except ZCLCommandNotFound:
-            logger.info("[zcl] command not found (command_identifier = 0x{:02x})".format(command_identifier))
+            logger.info("[zcl] command not found (command_identifier = 0x%02x)", command_identifier)
 
 
     # Decorators

--- a/whad/zigbee/stack/nwk/__init__.py
+++ b/whad/zigbee/stack/nwk/__init__.py
@@ -1086,7 +1086,7 @@ class NWKManager(Dot15d4Manager):
         )
         if securityMaterial not in networkSecurityMaterialSet:
             networkSecurityMaterialSet.append(securityMaterial)
-        logger.info("[nwk] new security material added: {}".format(str(securityMaterial)))
+        logger.info("[nwk] new security material added: %s", str(securityMaterial))
         self.database.set("nwkSecurityMaterialSet", networkSecurityMaterialSet)
 
 


### PR DESCRIPTION
Since Python 3.5, `binascii.hexlify` can be replaced by `bytes.hex()` and `bytes.fromhex()`.
Using `.hex()` in WHAD simplifies the code a bit as there is no longer a need to `.decode()` the value afterwards.

This patch also fixes a crash in `whad/dot15d4/address.py` in  `from_bytes` method where `hex_address` was uninitialized.