### PR TITLE
Add missing packaging dependency for APIMote virtual device (solves #241)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
     "requests>=2.28.0",
     "distro~=1.9",
     "websockets>=11.0.3",
+    "packaging~=25.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
A dependency was missing from WHAD's setup files (`packaging`), causing all CLI tools to crash because of an unhandled exception generated when importing modules.