### PR TITLE
Changed expected minimal ButteRFly version (solves #251)

### DIFF
--- a/whad/dot15d4/connector/__init__.py
+++ b/whad/dot15d4/connector/__init__.py
@@ -60,7 +60,7 @@ class Dot15d4(WhadDeviceConnector):
         # a critical bug has been found and fixed in version 1.1.0. FCS values
         # will be wrong if using a version prior to 1.1.0.
         if device.info.fw_url == "https://github.com/whad-team/butterfly":
-            if Version(device.info.version_str) < Version("1.1.0"):
+            if Version(device.info.version_str) < Version("1.0.2"):
                 message = ((
                     "You are using a ButteRFly version prior to 1.1.0 that does not correctly compute FCS values, "
                     "this will result in invalid FCS values in packets and PCAP files that may cause errors when "


### PR DESCRIPTION
ButteRFly version number has mistakenly been moved 1.0.1 (previous release version number) to 1.0.2 during the last release, overwriting the previously modified version number that was set to 1.1.0.

The problem is it causes WHAD to display a message to the user asking them to upgrade to the latest version while they are using in fact the latest one :S.

This fix solves this by checking the correct ButteRFly version (1.0.2).