### PR TITLE
Fix support of custom scapy layers in wextract, wfilter and wanalyze (issue #253)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
     "distro~=1.9",
     "websockets>=11.0.3",
     "packaging~=25.0",
+    "strenum~=0.4.15",
 ]
 
 [project.scripts]

--- a/whad/hub/__init__.py
+++ b/whad/hub/__init__.py
@@ -9,11 +9,27 @@ to protobuf messages fields.
 """
 import logging
 from typing import Union
-from whad.protocol.whad_pb2 import Message
+from enum import StrEnum
+
+
 from google.protobuf.message import DecodeError
+from scapy.config import conf
+
+from whad.protocol.whad_pb2 import Message
 from .registry import Registry
 
 logger = logging.getLogger(__name__)
+
+class Domain(StrEnum):
+    """Supported protocols."""
+
+    BLE = 'ble'
+    DOT15D4 = 'dot15d4'
+    ESB = 'esb'
+    PHY = 'phy'
+    RF4CE = 'rf4ce'
+    UNIFYING = 'unifying'
+    ZIGBEE = 'zigbee'
 
 class ProtocolHub(Registry):
     """WHAD Protocol Hub class
@@ -26,6 +42,22 @@ class ProtocolHub(Registry):
     NAME = 'hub'
     LAST_VERSION = 2
     VERSIONS = {}
+
+    @staticmethod
+    def set_domain(domain: Domain):
+        """Configure the hub for a specific domain.
+
+        This is where we can handle any specific configuration of Scapy
+        layers if required.
+
+        :param  domain: Domain to use
+        :type   domain: Domain
+        """
+        # Specify the chosen dot15d4 protocol, if specified
+        if domain == Domain.RF4CE:
+            conf.dot15d4_protocol = 'rf4ce'
+        elif domain == Domain.ZIGBEE:
+            conf.dot15d4_protocol = 'zigbee'
 
     def __init__(self, proto_version: int = LAST_VERSION):
         """Instantiate a WHAD protocol hub for a specific version.

--- a/whad/hub/__init__.py
+++ b/whad/hub/__init__.py
@@ -9,7 +9,14 @@ to protobuf messages fields.
 """
 import logging
 from typing import Union
-from enum import StrEnum
+
+# Load default Python's `StrEnum` class for Python >= 3.11
+# and rely on `StrEnum` package to provide this class for
+# previous Python versions.
+try:
+    from enum import StrEnum
+except ImportError:
+    from strenum import StrEnum
 
 
 from google.protobuf.message import DecodeError

--- a/whad/hub/dot15d4/pdu.py
+++ b/whad/hub/dot15d4/pdu.py
@@ -3,7 +3,9 @@
 import logging
 
 from struct import pack, unpack, error as StructError
+
 from scapy.layers.dot15d4 import Dot15d4, Dot15d4FCS
+
 from whad.scapy.layers.dot15d4tap import Dot15d4Raw
 from whad.hub.message import pb_bind, PbFieldInt, PbFieldBytes, PbMessageWrapper, \
     PbFieldBool, dissect_failsafe
@@ -54,7 +56,7 @@ class SendRawPdu(PbMessageWrapper):
         """Convert message to the corresponding scapy packet
         """
         return Dot15d4FCS(self.pdu + bytes(pack('<H', self.fcs)))
-        
+
     @staticmethod
     def from_packet(packet, channel: int = 11):
         """Convert a scapy packet to a SendPdu message

--- a/whad/hub/message.py
+++ b/whad/hub/message.py
@@ -329,7 +329,7 @@ class PbMessageWrapper(HubMessage):
             if value is not None:
                 fields.append((prop_name, value))
 
-        return f"<{self.__class__.__name__} " + ', '.join(
+        return f"<{self.__class__.__module__}.{self.__class__.__name__} " + ', '.join(
             [f'{name}={value}' for name, value in fields]
         ) + ">"
 

--- a/whad/hub/unifying/pdu.py
+++ b/whad/hub/unifying/pdu.py
@@ -4,6 +4,7 @@ from whad.protocol.whad_pb2 import Message
 from whad.scapy.layers.esb import ESB_Hdr, ESB_Payload_Hdr, ESB_Ack_Response, ESB_Pseudo_Packet
 from ..message import pb_bind, PbFieldBytes, PbFieldBool, PbFieldInt, PbMessageWrapper, \
     dissect_failsafe
+from whad.scapy.layers.unifying import bind
 from whad.hub.message import AbstractPacket
 from . import UnifyingDomain, UnifyingMetadata
 
@@ -77,6 +78,10 @@ class PduReceived(PbMessageWrapper):
     def to_packet(self):
         """Convert message to the corresponding scapy packet
         """
+        # Ensure our Unifying layers for scapy are correctly bound
+        bind()
+
+        # Build the Unifying packet (payload will be interpreted as Unifying header)
         packet = ESB_Payload_Hdr(bytes(self.pdu))
         packet.metadata = UnifyingMetadata()
         packet.metadata.channel = self.channel
@@ -132,6 +137,10 @@ class RawPduReceived(PbMessageWrapper):
     def to_packet(self):
         """Convert message to the corresponding scapy packet
         """
+        # Ensure our Unifying layers for scapy are correctly bound
+        bind()
+
+        # Build the Unifying packet (payload will be interpreted as Unifying header)
         packet = ESB_Hdr(bytes(self.pdu))
         packet.metadata = UnifyingMetadata()
         packet.metadata.channel = self.channel

--- a/whad/scapy/layers/__init__.py
+++ b/whad/scapy/layers/__init__.py
@@ -3,5 +3,14 @@
 This can be useful if you plan to read or write PCAP packets as DLT are also
 declared in these submodules.
 """
+from .phy import *
 from .dot15d4tap import *
 from .nordic import *
+from .bluetooth import *
+from .lorawan import *
+from .rf4ce import *
+from .esb import *
+from .unifying import *
+from .zdp import *
+from .zll import *
+

--- a/whad/scapy/layers/unifying.py
+++ b/whad/scapy/layers/unifying.py
@@ -1,3 +1,8 @@
+"""
+Logitech Unifying packets's definition classes for Scapy.
+"""
+import logging
+
 from scapy.packet import Packet, bind_layers
 from scapy.fields import ByteField, XByteField, X3BytesField, IntField, \
     StrFixedLenField, ShortField, ByteEnumField, XShortField, XShortEnumField, \
@@ -6,6 +11,8 @@ from struct import pack
 
 from whad.scapy.layers.esb import ESB_Payload_Hdr, SBAddressField, ESB_Ping_Request, \
     guess_payload_class_esb
+
+logger = logging.getLogger(__name__)
 
 class Logitech_Unifying_Hdr(Packet):
     name = "Logitech Unifying Payload"
@@ -220,7 +227,16 @@ bind_layers(Logitech_Unifying_Hdr, Logitech_Pairing_Complete_Payload,         fr
 
 
 def bind():
-    ESB_Payload_Hdr.guess_payload_class = guess_payload_class_unifying
+    """Override the ESB_Payload_Hdr payload guessing function with ours.
+    This will allow ESB PDU parsing to detect the Unifying payloads."""
+    # Check if current payload class guessing function is already set to ours,
+    # and update it if it is not the case.
+    if ESB_Payload_Hdr.guess_payload_class != guess_payload_class_unifying:
+        ESB_Payload_Hdr.guess_payload_class = guess_payload_class_unifying
+        logger.debug("ESB_Payload_Hdr's payload guessing function has been updated to detect Unifying packets.")
 
 def unbind():
+    """Restore the original payload class guessing function for ESB_Payload_Hdr."""
     ESB_Payload_Hdr.guess_payload_class = guess_payload_class_esb
+    logger.debug("ESB_Payload_Hdr's payload class guessing function has been restored to detect only ESB packets.")
+

--- a/whad/tools/wanalyze.py
+++ b/whad/tools/wanalyze.py
@@ -8,19 +8,18 @@ from time import sleep
 import logging
 from typing import List, Union, Tuple
 
-
 from prompt_toolkit import print_formatted_text, HTML
 from scapy.packet import Packet
 from scapy.config import conf
 from scapy.themes import BrightTheme
 
+from whad.scapy.layers import *
 from whad.cli.app import CommandLineApp, run_app
 from whad.device.unix import UnixConnector, UnixSocketServer
 from whad.device import Bridge
 from whad.hub import ProtocolHub
 from whad.cli.ui import error, success, info, display_packet, format_analyzer_output
 from whad.tools.utils import get_analyzers
-
 
 logger = logging.getLogger(__name__)
 #logging.basicConfig(level=logging.DEBUG)
@@ -296,6 +295,8 @@ class WhadAnalyzeApp(CommandLineApp):
                 if not self.args.nocolor:
                     conf.color_theme = BrightTheme()
 
+                # Configure the current domain
+                ProtocolHub.set_domain(self.args.domain)
 
                 #parameters = self.args.__dict__
                 connector = UnixConnector(interface)
@@ -348,3 +349,4 @@ def wanalyze_main():
     """
     app = WhadAnalyzeApp()
     run_app(app)
+

--- a/whad/tools/wanalyze.py
+++ b/whad/tools/wanalyze.py
@@ -1,7 +1,8 @@
-"""WHAD server tool
+"""
+WHAD analyzer
 
-This utility implements a server module, allowing to create a TCP proxy
-which can be used to access a device remotely.
+This utility processes incoming packets and feed one or more traffic analyzers
+with them, extracting and interpreting data based on various supported protocols.
 """
 import sys
 from time import sleep

--- a/whad/tools/wextract.py
+++ b/whad/tools/wextract.py
@@ -4,7 +4,6 @@ This utility implements a server module, allowing to create a TCP proxy
 which can be used to access a device remotely.
 """
 import sys
-import time
 import logging
 from typing import List, Tuple
 
@@ -13,6 +12,7 @@ from scapy.packet import Packet
 from scapy.config import conf
 from scapy.themes import BrightTheme
 
+from whad.scapy.layers import *
 from whad.cli.app import CommandLineApp, run_app
 from whad.device.unix import  UnixConnector
 from whad.hub import ProtocolHub
@@ -28,7 +28,7 @@ class WhadExtractApp(CommandLineApp):
         """Application uses an interface and has commands.
         """
         super().__init__(
-            description='WHAD filter tool',
+            description='WHAD extraction tool',
             interface=True,
             commands=False,
             input=CommandLineApp.INPUT_WHAD,
@@ -141,9 +141,12 @@ class WhadExtractApp(CommandLineApp):
                 # Create a Unix socket connector
                 connector = UnixConnector(interface)
 
+                # Enable the specified domain in the hub
+                ProtocolHub.set_domain(self.args.domain)
+
                 # Set the connector domain
                 connector.domain = self.args.domain
-                hub = ProtocolHub(2)
+                hub = ProtocolHub()
                 connector.format = hub.get(self.args.domain).format
                 connector.on_packet = self.on_packet
 


### PR DESCRIPTION
A regression has been detected related to the way `wextract`, `wfilter` and `wanalyze` tools filter packets, i.e. without supporting WHAD's custom Scapy packet definitions.

This pull request solves this issue by restoring access to WHAD's own Scapy layers in these tools, as well as fixing a few typos and documentation issues.