### PR TITLE
Improved BLE scanner and sniffer connectors, fixed errors in documentation (fixes #264)

### DIFF
--- a/doc/source/api/device.rst
+++ b/doc/source/api/device.rst
@@ -1,5 +1,44 @@
-Device and connector
-====================
+
+Devices and connectors
+======================
+
+In WHAD, *devices* and *connectors* are two different components that are used
+together to allow users and applications to perform various actions on wireless
+networks, using compatible hardware.
+
+A *device* defines a compatible hardware device that is plugged to the host
+computer running WHAD, could it be an internal device present on a motherboard
+or an external device connected through a USB port. Such a device is represented
+in WHAD by a class that derives from the :py:class:`~whad.device.device.Device` class
+acting as an interface between the framework and the real hardware used to communicate
+over the air with other networks and peripherals.
+
+WHAD support the following hardware devices:
+- Internal bluetooth adapters (installed on motherboard), supporting at least Bluetooth version >= 4.0
+- USB Bluetooth dongles, supporting at least Bluetooth version >= 4.0
+- [Great Scott Gadgets' Ubertooth One](https://greatscottgadgets.com/ubertoothone/)
+- [Great Scott Gadgets' Yard Stick One](https://greatscottgadgets.com/yardstickone/)
+- [River Loop Security's ApiMote](http://apimote.com/)
+- [Nordic nRF52840 USB dongle](https://www.nordicsemi.com/Products/Development-hardware/nRF52840-Dongle)
+- [Maker Diary's nRF52840 MDK USB dongle](https://makerdiary.com/products/nrf52840-mdk-usb-dongle)
+
+Some devices are supported natively (running a custom firmware implementing our WHAD protocol) while others
+are supported through a dedicated adaptation layer in a dedicated class inheriting from
+:py:class:`~whad.device.device.VirtualDevice`. 
+
+Device classes are strongly tied to a specific hardware (and firmware, if required)
+and basically take WHAD messages in input and output WHAD messages too. WHAD protocol
+includes a discovery feature allowing each device to tell the host computer what *domains*
+it support (think of *domains* as *wireless protocols*) and its *capabilities* for
+each of them, as well as the set of *commands* supported for each *domain*.
+
+*Connectors* on the other hand are not tied to any specific hardware but rather to
+a specific *domain* and a set of *capabilities*. A *connector* acts as a specialized
+role applied to a compatible hardware device, and exposes a set of actions that can
+be used by any application, no matter the hardware since it at least supports the
+required *domain* and *capabilities*. This way, any high-level interaction implemented
+in a *connector* can be used with any hardware that provides the required *capabilities*
+for a given *domain*, making it easier to create custom firmwares for new hardware
+without having to care about how some wireless attack or procedure is implemented.
 
 .. automodule:: whad.device
-    :members: WhadDevice, VirtualDevice, WhadDeviceConnector, WhadDeviceInfo, Bridge

--- a/doc/source/ble/scanner.rst
+++ b/doc/source/ble/scanner.rst
@@ -1,10 +1,30 @@
 Device Scanning
 ===============
 
-Bluetooth Low Energy scanning is provided by a dedicated connector, :class:`whad.ble.connector.Scanner`,
+Bluetooth Low Energy scanning is provided by a dedicated connector, :class:`~whad.ble.connector.Scanner`,
 that drives a BLE-enable WHAD device to detect any available BLE device. This connector relies
-on an internal database implemented in :class:`whad.ble.scanning.AdvertisingDevicesDB` that keeps
+on an internal database implemented in :class:`~whad.ble.scanning.AdvertisingDevicesDB` that keeps
 track of every detected device.
+
+Discovering devices with this connector is pretty simple:
+
+.. code-block:: python
+
+    from whad.device import Device
+    from whad.ble import Scanner
+
+    # Access hardware interface hci0
+    dev = Device.create("hci0")
+
+    # Scan for devices for 30 seconds
+    with Scanner(dev) as scanner:
+        for device in scanner.discover_devices(timeout=30.0):
+            print(device)
+
+.. note::
+
+    It is recommended to use the :class:`~whad.ble.Scanner` connector within a
+    `with` statement to proper device initialization and cleanup.
 
 Bluetooth Low Energy Scanner connector
 --------------------------------------
@@ -18,7 +38,7 @@ BLE device tracking database
 ----------------------------
 
 Devices are tracked by the BLE scanner connector by a dedicated database, each
-device is then wrapped into a :class:`whad.ble.scanning.AdvertisingDevice` instance
+device is then wrapped into a :class:`~whad.ble.scanning.AdvertisingDevice` instance
 that holds all the interesting information.
 
 .. autoclass:: whad.ble.scanning.AdvertisingDevice

--- a/doc/source/ble/started.rst
+++ b/doc/source/ble/started.rst
@@ -9,19 +9,29 @@ a BLE device scanner and detect all the available devices.
 
 .. code-block:: python
 
-    from whad import UartDevice
+    from whad.device import Device
     from whad.ble import Scanner
 
-    scanner = Scanner(UartDevice('/dev/ttyUSB0'))
-    scanner.start()
-    for rssi, advertisement in scanner.discover_devices():
-        advertisement.show()
+    scanner = Scanner(Device.create("hci0"))
+    for device in scanner.discover_devices():
+        print(device)
 
+:class:`~whad.ble.connector.scanner.Scanner` can also be used within a
+`with` statement, as shown below:
+
+.. code-block:: python
+
+    from whad.device import Device
+    from whad.ble import Scanner
+
+    with Scanner(Device.create("hci0")) as scanner:
+        for device in scanner.discover_devices():
+            print(device)
 
 Initiate a connection to a BLE device
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use the :class:`whad.ble.connector.central.Central` class to create a
+Use the :class:`~whad.ble.connector.central.Central` class to create a
 BLE central device and initiate a connection to a BLE peripheral device.
 
 .. code-block:: python
@@ -197,7 +207,7 @@ and :py:class:`whad.ble.connector.Central` connector provides a nifty way to do 
 
     # Make sure connection has succeeded
     if device is not None:
-        
+
         # Enable synchronous mode: we must process any incoming BLE packet.
         central.enable_synchronous(True)
 

--- a/examples/ble/ble_scanner.py
+++ b/examples/ble/ble_scanner.py
@@ -1,31 +1,32 @@
 from whad.ble import Scanner
-from whad.device import WhadDevice
+from whad.device import Device
 from whad.exceptions import WhadDeviceNotFound
-from time import time,sleep
 import sys
 
 if __name__ == '__main__':
     if len(sys.argv) >= 2:
         # Retrieve target interface
         interface = sys.argv[1]
+        dev = None
 
         try:
-            # Create the device
-            dev = WhadDevice.create(interface)
+            # Access our interface
+            dev = Device.create(interface)
 
-            # Create the Scanner connector
-            scanner = Scanner(dev)
+            # Attach a scanner role and scan devices
+            with Scanner(dev) as scanner:
+                for remote_dev in scanner.discover_devices():
+                    print(remote_dev)
 
-            # Start the scanner and iterate over devices
-            scanner.start()
-            for i in scanner.discover_devices():
-                print(i)
-
+        # Handle interruptions (user or system)
         except (KeyboardInterrupt, SystemExit):
-            dev.close()
+            if dev is not None:
+                dev.close()
 
+        # Device not found ?
         except WhadDeviceNotFound:
             print('[e] Device not found')
             exit(1)
     else:
         print('Usage: %s [device]' % sys.argv[0])
+

--- a/tests/domain/ble/test_scanner.py
+++ b/tests/domain/ble/test_scanner.py
@@ -4,6 +4,7 @@ import pytest
 
 from whad.ble.mock import DeviceScan, EmulatedDevice
 from whad.ble import BDAddress, Scanner
+from whad.exceptions import WhadDeviceNotReady
 
 @pytest.fixture
 def mock_devices():
@@ -45,6 +46,9 @@ def test_scanner_scan_devices(scan_mock):
 
 def test_scanner_scan_devices_with_forced_start(scan_mock):
     """Test scanner scan-based device discovery
+
+    `Scanner` instance must stay started if already started
+    before calling `discover_devices()`.
     """
     scanner = Scanner(scan_mock)
     scanner.start()
@@ -53,6 +57,7 @@ def test_scanner_scan_devices_with_forced_start(scan_mock):
         devices.append(device.address)
         break
     assert "00:11:22:33:44:55" in devices
+    assert scanner.started
 
 def test_scanner_scan_devices_with_context(scan_mock):
     """Test scanner device discovery when used in a `with` statement."""
@@ -64,6 +69,12 @@ def test_scanner_scan_devices_with_context(scan_mock):
             break
     assert "00:11:22:33:44:55" in devices
     assert scan_mock.stopped
+
+def test_scanner_exception_within_context(scan_mock):
+    """Test scanner device discovery when used in a `with` statement."""
+    with pytest.raises(WhadDeviceNotReady):
+        with Scanner(scan_mock):
+            raise WhadDeviceNotReady()
 
 def test_scanner_sniffing(sniff_mock):
     """Test scanner instantiation with hardware only supporting sniffing

--- a/tests/domain/ble/test_scanner.py
+++ b/tests/domain/ble/test_scanner.py
@@ -37,12 +37,33 @@ def test_scanner_scan_devices(scan_mock):
     """Test scanner scan-based device discovery
     """
     scanner = Scanner(scan_mock)
+    devices = []
+    for device in scanner.discover_devices(timeout=2.0):
+        devices.append(device.address)
+        break
+    assert "00:11:22:33:44:55" in devices
+
+def test_scanner_scan_devices_with_forced_start(scan_mock):
+    """Test scanner scan-based device discovery
+    """
+    scanner = Scanner(scan_mock)
     scanner.start()
     devices = []
     for device in scanner.discover_devices(timeout=2.0):
         devices.append(device.address)
         break
     assert "00:11:22:33:44:55" in devices
+
+def test_scanner_scan_devices_with_context(scan_mock):
+    """Test scanner device discovery when used in a `with` statement."""
+    devices = []
+    with Scanner(scan_mock) as scanner:
+        assert isinstance(scanner, Scanner)
+        for device in scanner.discover_devices():
+            devices.append(device.address)
+            break
+    assert "00:11:22:33:44:55" in devices
+    assert scan_mock.stopped
 
 def test_scanner_sniffing(sniff_mock):
     """Test scanner instantiation with hardware only supporting sniffing

--- a/tests/domain/ble/test_sniffer.py
+++ b/tests/domain/ble/test_sniffer.py
@@ -28,12 +28,33 @@ def test_sniffer_create(sniff_mock):
     """Test creating a Bluetooth sniffer.
     """
     sniffer = Sniffer(sniff_mock)
-    sniffer.start()
     packets = []
     for packet in sniffer.sniff(timeout=2.0):
         packets.append(packet)
         break
     sniffer.stop()
+    assert packets[0][BTLE_ADV_IND].AdvA == "00:11:22:33:44:55"
+
+def test_sniffer_create_with_forced_start(sniff_mock):
+    """Test creating a Bluetooth sniffer.
+    """
+    sniffer = Sniffer(sniff_mock)
+    packets = []
+    sniffer.start()
+    for packet in sniffer.sniff(timeout=2.0):
+        packets.append(packet)
+        break
+    sniffer.stop()
+    assert packets[0][BTLE_ADV_IND].AdvA == "00:11:22:33:44:55"
+
+def test_sniffer_create_with_context(sniff_mock):
+    """Test creating a Bluetooth sniffer.
+    """
+    packets = []
+    with Sniffer(sniff_mock) as sniffer:
+        for packet in sniffer.sniff(timeout=2.0):
+            packets.append(packet)
+            break
     assert packets[0][BTLE_ADV_IND].AdvA == "00:11:22:33:44:55"
 
 def test_sniffer_channel_set(sniff_mock):
@@ -48,7 +69,6 @@ def test_sniffer_channel_set(sniff_mock):
     sniffer.configuration = sniffer_cfg
 
     # Sniff for advertisement data
-    sniffer.start()
     packets = []
     for packet in sniffer.sniff(timeout=2.0):
         packets.append(packet)
@@ -67,7 +87,6 @@ def test_sniffer_channel_default(sniff_mock):
     sniffer.configuration = sniffer_cfg
 
     # Sniff for advertisement data
-    sniffer.start()
     packets = []
     for packet in sniffer.sniff(timeout=2.0):
         packets.append(packet)
@@ -87,7 +106,6 @@ def test_sniffer_address_filter_match(sniff_mock):
     sniffer.configuration = sniffer_cfg
 
     # Sniff for advertisement data
-    sniffer.start()
     packets = []
     for packet in sniffer.sniff(timeout=2.0):
         packets.append(packet)
@@ -116,7 +134,6 @@ def test_sniffer_address_filter_nomatch(sniff_mock):
     sniffer.configuration = sniffer_cfg
 
     # Sniff for advertisement data
-    sniffer.start()
     packets = []
     for packet in sniffer.sniff(timeout=0.5):
         packets.append(packet)

--- a/whad/ble/__init__.py
+++ b/whad/ble/__init__.py
@@ -6,22 +6,33 @@ import re
 from whad.ble.stack.gatt import GattClient, GattServer
 from whad.common.triggers import ManualTrigger, ConnectionEventTrigger, ReceptionTrigger
 from whad.hub.ble.bdaddr import BDAddress
+from whad.hub.ble.chanmap import ChannelMap
 from whad.ble.profile import GenericProfile
-from whad.ble.profile.advdata import AdvDataFieldList, AdvFlagsField, AdvDataField, AdvCompleteLocalName, \
-    AdvManufacturerSpecificData, AdvShortenedLocalName, AdvTxPowerLevel, AdvDataFieldListOverflow, AdvDataError
+from whad.ble.profile.advdata import (
+    AdvDataFieldList, AdvFlagsField, AdvDataField, AdvCompleteLocalName,
+    AdvManufacturerSpecificData, AdvShortenedLocalName, AdvTxPowerLevel,
+    AdvDataFieldListOverflow, AdvURI, AdvLeRole, AdvAppearance, AdvUuid128List,
+    AdvUuid16List, AdvDataError
+)
 from whad.ble.connector.base import BLE
-from whad.ble.connector import Central, Peripheral, Sniffer, Hijacker, Injector, Scanner, PeripheralClient
+from whad.ble.connector import (
+    Central, Peripheral, Sniffer, Hijacker, Injector, Scanner, PeripheralClient, Scanner
+)
 from whad.ble.utils.phy import PHYS
 
 def is_bdaddr_valid(bd_addr):
     return re.match('^([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}$',bd_addr)
 
 __all__ = [
+    # Basic types for BLE
     'BLE',
+    'ChannelMap',
     'GattClient',
     'GattServer',
     'BDAddress',
     'GenericProfile',
+
+    # Advertising data classes
     'AdvDataFieldList',
     'AdvFlagsField',
     'AdvDataField',
@@ -30,7 +41,14 @@ __all__ = [
     'AdvShortenedLocalName',
     'AdvTxPowerLevel',
     'AdvDataFieldListOverflow',
+    'AdvURI',
+    'AdvLeRole',
+    'AdvAppearance',
+    'AdvUuid128List',
+    'AdvUuid16List',
     'AdvDataError',
+
+    # Connectors
     'Central',
     'Peripheral',
     'PeripheralClient',
@@ -38,6 +56,8 @@ __all__ = [
     'Hijacker',
     'Injector',
     'Scanner',
+
+    # Misc.
     'PHYS',
     'ConnectionEventTrigger',
     'ManualTrigger',

--- a/whad/ble/connector/central.py
+++ b/whad/ble/connector/central.py
@@ -11,6 +11,7 @@ weird reasons).
 import logging
 from time import sleep
 from threading import Event
+from typing import Optional
 
 from whad.device.connector import Event as CentralEvent
 from whad.common.stack import Layer
@@ -267,7 +268,7 @@ class Central(BLE):
         # Raise error
         raise PeripheralNotFound()
 
-    def peripheral(self) -> PeripheralDevice:
+    def peripheral(self) -> Optional[PeripheralDevice]:
         """Connected BLE peripheral.
         """
         return self.__peripheral

--- a/whad/ble/mock/scan.py
+++ b/whad/ble/mock/scan.py
@@ -91,6 +91,16 @@ class DeviceScan(MockDevice):
             )
         }
 
+    @property
+    def started(self) -> bool:
+        """Check if mock device is started."""
+        return self.__running
+
+    @property
+    def stopped(self) -> bool:
+        """Check if mock device is stopped."""
+        return not self.__running
+
     def accept(self, bdaddr: BDAddress) -> bool:
         """Apply BD filter if required.
         """

--- a/whad/device/__init__.py
+++ b/whad/device/__init__.py
@@ -1,13 +1,122 @@
-"""WHAD hardware module
+"""
+Devices
+-------
 
-This module provides various classes to interact with WHAD-enabled hardware:
+WHAD provides various classes to interact with WHAD-enabled hardware:
 
-- :py:class:`whad.hw.Interface`
-- :py:class:`whad.hw.VirtInterface`
+- :py:class:`whad.device.device.Device`
+- :py:class:`whad.device.device.VirtualDevice`
 
-This module replaces the previous `whad.device` module and its ambiguous class
-names and features. The `whad.device` module is still available but will be
-considered deprecated in a future release.
+Class :class:`whad.device.device.Device` is the default class that allows WHAD devices
+enumeration and access. It is the main class to use to open any device, through
+its :py:meth:`whad.device.Device.create` method as shown below:
+
+.. code-block:: python
+
+    from whad.device import Device
+
+    dev = Device.create("uart0")
+
+The :py:class:`whad.device.device.VirtualDevice` shall not be directly used. This class
+is used to add support for incompatible WHAD devices like the *Ubertooth*
+or the *ApiMote* and acts as an adaptation layer between the underlying WHAD
+protocol and the specific protocol used by the target hardware.
+
+.. important::
+
+    The :py:class:`whad.device.device.WhadDevice` class that is still defined in WHAD (and used
+    in some old example scripts or documentation) is an alias for the new
+    :py:class:`whad.device.device.Device` class, and is meant to be deprecated in the future.
+    This old class has been renamed to ``Device`` for clarity, and the same happened
+    with the old default connector class :py:class:`whad.device.connector.WhadConnector`
+    that has been renamed to :py:class:`whad.device.connector.Connector`.
+
+    These old classes will be marked as *deprecated* in a future release, with a
+    specific EOL date announced. A warning message will be issued in case one of
+    these classes is used in a script or a tool to give time to users to migrate
+    to the new ones (renaming classes is enough to switch to the new implementation,
+    APIs stay the same).
+
+
+.. autoclass:: whad.device.device.Device
+    :members:
+
+.. autoclass:: whad.device.device.VirtualDevice
+    :members:
+
+
+Connectors
+----------
+
+*Connectors* shall ensure the device they are linked to does support the
+target domain and a mimimal set of commands, and can tailor its behavior
+depending on the capabilities of the hardware. If a *connector* is linked
+to a device that either does not support the *domain* this *connector* is
+supposed to operate or lacks specific *commands*, a
+:py::class:`whad.exceptions.UnsupportedDomain` exception or a
+:py:class:`whad.exceptions.UnsupportedCapability` may be raised.
+
+WHAD provides a default connector class, :py:class:`whad.device.connector.Connector`,
+that implements a set of features out-of-the-box:
+
+- Packet and message sniffing and processing
+- Event notification mechanism
+- Synchronous mode
+
+Sniffing packet and messages could be useful to implement packet sniffers or
+intercept some specific events like disconnection of the linked hardware device.
+Most of the time this feature is used to sniff packets related to a target domain.
+The :py:meth:`whad.device.connector.Connector.sniff` method is specifically
+tailored for this use. When not sniffing, packets received from the hardware device
+are forwarded to the connector's packet processing methods than can be overriden by
+inheriting classes.
+
+By default, the default connector class provides methods to add and remove custom
+event listeners (:py:meth:`whad.device.connector.Connector.add_listener` and
+:py:meth:`whad.device.connector.Connector.remove_listener`), and an additional
+method to send an event to the registered listeners (:py:meth:`whad.device.connector.Connector.notify`).
+
+Last but not least, the provided *synchronous mode* will disable packet forwarding
+and save all received packets in a reception queue, waiting for the application to
+retrieve and process them. Service messages will still be processed by the *connector*,
+in order to handle any device disconnection or other unexpected event that may occur.
+When this *synchronous mode* is disabled, every unprocessed packet stored in the
+reception queue are automatically forwarded to the connector's packet processing
+methods, and will be then dispatched to the corresponding handlers.
+
+.. autoclass:: whad.device.connector.Connector
+    :members:
+
+    .. automethod:: __init__
+
+.. autoclass:: whad.device.connector.LockedConnector
+    :members:
+
+    .. automethod:: __init__
+
+Deprecated classes
+------------------
+
+In early versions of WHAD, device and connector base classes had different names
+that were too long and badly chosen. We took the decision to rename them while
+keeping the old classes as aliases of the new ones. This way, old code and documentation
+and even tools keep working as expected, until we decide to definitely deprecate
+these old classes. For now, they are still defined and available, but we will mark
+them as deprecated starting from version 1.3.
+
+A warning will be displayed each time such a class is used, inciting users and
+maintainers to update their code to use the new classes, which are strictly
+compatible as they expose the same methods and properties. This warning will
+include a deadline after which these classes will be definitely removed.
+
+.. autoclass:: whad.device.device.WhadDevice
+    :show-inheritance:
+
+.. autoclass:: whad.device.device.WhadVirtualDevice
+    :show-inheritance:
+
+.. autoclass:: whad.device.connector.WhadDeviceConnector
+    :show-inheritance:
 """
 
 # Load interface base classes
@@ -47,7 +156,7 @@ __all__ = [
     "WhadVirtualDevice",
     "WhadDeviceConnector",
     "LockedConnector",
-    
+
     # Virtual devices
     "Hci",
     "Pcap",

--- a/whad/device/connector.py
+++ b/whad/device/connector.py
@@ -1,17 +1,54 @@
 """
-WHAD default device connector module.
+Connectors
+----------
 
-This module provides a default connector class `WhadDeviceConnector` that
-implements all the basic features of a device connector:
+*Connectors* in WHAD are dedicated classes used to connect an *application*
+to a WHAD compatible hardware (any compatible *device*) in order to provide
+a set of features. We can see a *connector* as a role applied to a device,
+usually related to a *domain* (or *wireless protocol*), that exposes methods
+to perform various tasks that rely on a subset of commands supported by the
+hardware.
 
-- Sending and receiving messages
-- A synchronous mode used for message sniffing and processing
-- A locked mode (enabled by default) to temporarily save messages while the connector
-  is initializing (no more message lost)
-- A dedicated notification manager and basic notification class to allow external objects
-  to subscribe for specific notifications.
+*Connectors* shall ensure the device they are linked to does support the
+target domain and a mimimal set of commands, and can tailor its behavior
+depending on the capabilities of the hardware. If a *connector* is linked
+to a device that either does not support the *domain* this *connector* is
+supposed to operate or lacks specific *commands*, a
+:py::class:`whad.exceptions.UnsupportedDomain` exception or a
+:py:class:`whad.exceptions.UnsupportedCapability` may be raised.
 
+Default connector features
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+WHAD provides a default connector class, :py:class:`whad.device.connector.Connector`,
+that implements a set of features out-of-the-box:
+
+- Packet and message sniffing and processing
+- Event notification mechanism
+- Synchronous mode
+
+Sniffing packet and messages could be useful to implement packet sniffers or
+intercept some specific events like disconnection of the linked hardware device.
+Most of the time this feature is used to sniff packets related to a target domain.
+The :py:function:`whad.device.connector.Connector.sniff` method is specifically
+tailored for this use. When not sniffing, packets received from the hardware device
+are forwarded to the connector's packet processing methods than can be overriden by
+inheriting classes.
+
+By default, the default connector class provides methods to add and remove custom
+event listeners (:py:function:`whad.device.connector.Connector.add_listener` and
+:py:function:`whad.device.connector.Connector.remove_listener`), and an additional
+method to send an event to the registered listeners (:py:function:`whad.device.connector.Connector.notify`).
+
+Last but not least, the provided *synchronous mode* will disable packet forwarding
+and save all received packets in a reception queue, waiting for the application to
+retrieve and process them. Service messages will still be processed by the *connector*,
+in order to handle any device disconnection or other unexpected event that may occur.
+When this *synchronous mode* is disabled, every unprocessed packet stored in the
+reception queue are automatically forwarded to the connector's packet processing
+methods, and will be then dispatched to the corresponding handlers.
 """
+
 import logging
 import contextlib
 from time import time
@@ -887,4 +924,8 @@ class LockedConnector(Connector):
 
 
 class WhadDeviceConnector(Connector):
-    """Old class"""
+    """
+    This class is an alias for :py:class:`whad.device.connector.Connector`,
+    and will be deprecated in a near future. This class has been introduced
+    in a previous version of WHAD and has been renamed for clarity purpose.
+    """

--- a/whad/device/device.py
+++ b/whad/device/device.py
@@ -1,4 +1,58 @@
-"""WHAD new hardware interface
+"""
+WHAD provides various classes to interact with WHAD-enabled hardware:
+
+- :py:class:`whad.device.device.Device`
+- :py:class:`whad.device.device.VirtualDevice`
+
+Class :class:`whad.device.device.Device` is the default class that allows WHAD devices
+enumeration and access. It is the main class to use to open any device, through
+its :method:`whad.device.Device.create` method as shown below:
+
+.. code-block:: python
+
+    from whad.device import Device
+
+    dev = Device.create("uart0")
+
+The :py:class:`whad.device.device.VirtualDevice` shall not be directly used. This class
+is used to add support for incompatible WHAD devices like the *Ubertooth*
+or the *ApiMote* and acts as an adaptation layer between the underlying WHAD
+protocol and the specific protocol used by the target hardware.
+
+.. important::
+
+    The :py:class:`whad.device.device.WhadDevice` class that is still defined in WHAD (and used
+    in some old example scripts or documentation) is an alias for the new
+    :py:class:`whad.device.Device` class, and is meant to be deprecated in the future.
+    This old class has been renamed to ``Device`` for clarity, and the same happened
+    with the old default connector class :py:class:`whad.device.connector.WhadConnector`
+    that has been renamed to :py:class:`whad.device.connector.Connector`.
+
+    These old classes will be marked as *deprecated* in a future release, with a
+    specific EOL date announced. A warning message will be issued in case one of
+    these classes is used in a script or a tool to give time to users to migrate
+    to the new ones (renaming classes is enough to switch to the new implementation,
+    APIs stay the same).
+
+Default device classes
+----------------------
+
+.. autoclass:: whad.device.device.Device
+    :members:
+
+.. autoclass:: whad.device.device.VirtualDevice
+    :show-inheritance:
+    :members:
+
+Old device classes to be deprecated in the future
+-------------------------------------------------
+
+.. autoclass:: whad.device.device.WhadDevice
+    :show-inheritance:
+
+.. autoclass:: whad.device.device.WhadVirtualDevice
+    :show-inheritance:
+
 """
 import re
 import logging
@@ -999,7 +1053,11 @@ class VirtualDevice(Device):
 
 
 class WhadDevice(Device):
-    """Renamed to `Device` for clarity, will be deprecated later."""
+    """
+    This class is an alias for :py:class:`whad.device.device.Device`,
+    and will be deprecated in a near future. This class has been introduced
+    in a previous version of WHAD and has been renamed for clarity purpose.
+    """
 
     @classmethod
     def create_inst(cls, interface_string):
@@ -1017,7 +1075,11 @@ class WhadDevice(Device):
         return Device.check_interface(interface)
 
 class WhadVirtualDevice(VirtualDevice):
-    """Renamed to `VirtualDevice` for clarity, will be deprecated later."""
+    """
+    This class is an alias for :py:class:`whad.device.device.VirtualDevice`,
+    and will be deprecated in a near future. This class has been introduced
+    in a previous version of WHAD and has been renamed for clarity purpose.
+    """
 
     @classmethod
     def create_inst(cls, interface_string):


### PR DESCRIPTION
BLE ``Scanner`` and ``Sniffer`` required a call to ``start()`` before scanning or sniffing, which is quite easily to forget. These connectors have been modified to implement a context manager as well as some checks to automatically send a ``StartCmd`` to the WHAD device before starting scanning or sniffing, in order to avoid silent issues to happen.

Based on the feedback of many workshops we gave, it is not *natural* to call the connector's ``start()`` method before starting a scan or sniffing packets. 

The proposed implementation adds support for Python's `with` statement like the following:

```python
from whad.device import Device
from whad.ble import Scanner

with Scanner(Device.create("hci0")) as scanner:
    for device in scanner.discover_devices(timeout=30.0):
        print(device)
```

That's damn simple and you don't have to deal with ``start()`` or ``stop()``, everything is handled by the underlying context manager.