### PR TITLE
Adding support for sub-domains in lazy loading

### DIFF
--- a/whad/hub/__init__.py
+++ b/whad/hub/__init__.py
@@ -121,7 +121,7 @@ class ProtocolHub(Registry):
         elif factory == 'ble':
             from .ble import BleDomain
             return BleDomain
-        elif factory == 'dot15d4':
+        elif factory in ('dot15d4', 'rf4ce', 'zigbee'):
             from .dot15d4 import Dot15d4Domain
             return Dot15d4Domain
         elif factory == 'esb':


### PR DESCRIPTION
Fixed a bug in WHAD lazy loading that caused an error when using sub-domains like ``rf4ce` or ``zigbee`` (built upon ``dot15d4``).