### PR TITLE
Improved device closing procedure to avoid latency

### DIFF
--- a/whad/device/device.py
+++ b/whad/device/device.py
@@ -659,10 +659,8 @@ class Device:
         """
         if self.__iface_in is not None:
             self.__iface_in.cancel()
-            self.__iface_in.join()
         if self.__iface_out is not None:
             self.__iface_out.cancel()
-            self.__iface_out.join()
 
     ##
     # Device specific methods


### PR DESCRIPTION
Modified WHAD's default device class to avoid waiting for the associated I/O threads to terminate properly.

Fixes #280.