### PR TITLE
Fixed a regression in ESB's sniffing connector

### DIFF
--- a/whad/esb/connector/base.py
+++ b/whad/esb/connector/base.py
@@ -157,7 +157,7 @@ class ESB(Connector):
             (commands & (1 << Commands.SetNodeAddress)) > 0
         )
 
-    def sniff(self, channel : int = None, address : str = "FF:FF:FF:FF:FF",
+    def start_sniff(self, channel : int = None, address : str = "FF:FF:FF:FF:FF",
               show_acknowledgements : bool = False):
         """
         Sniff Enhanced ShockBurst packets.

--- a/whad/esb/connector/sniffer.py
+++ b/whad/esb/connector/sniffer.py
@@ -12,13 +12,11 @@ By default, the *Enhanced ShockBurst* sniffer sniffs packet on all channels by
 looping from channel 0 to 100 over and over and capturing frames that match
 the expected format.
 """
-from time import time
 from typing import Generator
 
 from scapy.packet import Packet
 
 from whad.device import Device
-from whad.helpers import message_filter
 from whad.exceptions import WhadDeviceDisconnected, UnsupportedCapability
 from whad.common.sniffing import EventsManager
 
@@ -59,7 +57,7 @@ class Sniffer(ESB, EventsManager):
         ack = self.__configuration.acknowledgements
         address = self.__configuration.address
 
-        super().sniff(channel=channel, show_acknowledgements=ack, address=address)
+        super().start_sniff(channel=channel, show_acknowledgements=ack, address=address)
         self.start()
 
     @property
@@ -136,7 +134,7 @@ class Sniffer(ESB, EventsManager):
             message_type = PduReceived
 
         try:
-            for message in super().sniff(message=(message_type), timeout=timeout):
+            for message in super().sniff(messages=(message_type), timeout=timeout):
                 if message is not None and issubclass(message, AbstractPacket):
                     packet = message.to_packet()
                     if packet is not None:


### PR DESCRIPTION
ESB's base connector has its `sniff()` method redefined by its associated `Sniffer` class, causing an exception when using `wsniff` in ESB mode. This fix solves this by renaming the base connector's `sniff()` method to `start_sniff()` method, like we previously did for the Unifying base connector (it seems we forgot to fix the same issue for ESB).