### PR TITLE
Fixed a bug with notification subscription in wble-central 

### DIFF
--- a/whad/ble/cli/central/shell.py
+++ b/whad/ble/cli/central/shell.py
@@ -1084,7 +1084,7 @@ class BleCentralShell(InteractiveShell):
 
             # If UUID is provided
             if isinstance(handle, UUID):
-                target_charac = self.__target.find_characteristic_by_uuid(handle)
+                target_charac = self.__target.char(handle)
             elif isinstance(handle, int):
                 try:
                     target_charac = self.__target.find_object_by_handle(handle)
@@ -1195,7 +1195,7 @@ class BleCentralShell(InteractiveShell):
 
             # If UUID is provided
             if isinstance(handle, UUID):
-                target_charac = self.__target.find_characteristic_by_uuid(handle)
+                target_charac = self.__target.char(handle)
             elif isinstance(handle, int):
                 try:
                     target_charac = self.__target.find_object_by_handle(handle)


### PR DESCRIPTION
wble-central shell used an old method that was removed in a previous  API refactoring, causing an exception to be raised and the program to abruptly exit.