### PR TITLE
Sniffer now displays a warning when an unsupported packet size is specified (fixes #328)

### DIFF
--- a/whad/phy/connector/injector.py
+++ b/whad/phy/connector/injector.py
@@ -1,10 +1,14 @@
 """PHY Injector connector
 """
+import logging
+
 from whad.phy.connector import Phy
 from whad.hub.phy import Modulation as PhyModulation, Endianness as PhyEndianness
 from whad.phy.injecting import InjectionConfiguration
 from whad.scapy.layers.phy import Phy_Packet
 from whad.exceptions import UnsupportedCapability
+
+logger = logging.getLogger(__name__)
 
 # TODO: every sniffer is broken (sniff() method does not catch packets, we
 #       have to catch them in on_packet() and put them in a queue)
@@ -39,7 +43,10 @@ class Injector(Phy):
         if self.__configuration.frequency is not None:
             self.set_frequency(self.__configuration.frequency)
         if self.__configuration.packet_size is not None:
-            self.set_packet_size(self.__configuration.packet_size)
+            if not self.set_packet_size(self.__configuration.packet_size):
+                logger.warning(("[WARNING] Hardware rejected the specified packet size (%d), "
+                                "will use its maximum packet size instead."),
+                               self.__configuration.packet_size)
 
         # Set data rate for all modulations but LoRa
         if not self.__configuration.lora:

--- a/whad/phy/connector/sniffer.py
+++ b/whad/phy/connector/sniffer.py
@@ -86,7 +86,7 @@ class Sniffer(Phy, EventsManager):
 
         # Set packet size, display a warning if hardware rejects the provided value.
         if not self.set_packet_size(self.__configuration.packet_size):
-            logger.warning("hardware rejected the provided packet size (%d) and will use its default value instead.",
+            logger.warning("[WARNING] Hardware rejected the provided packet size (%d) and will use its maximum packet size instead.",
                             self.__configuration.packet_size)
 
         # Set data rate for all modulations but LoRa.


### PR DESCRIPTION
Invalid or unsupported packet size passed to a PHY's `Sniffer` class instance did not raise any error nor warning, puzzling users as captured data's size did not match the specified packet size. The hardware device used for sniffing did in fact reject the specified packet size value but the `Sniffer` class did not check the response and considered the packet size set on hardware's side.

A warning has been added in order not to disrupt existing implementations and to avoid critical regressions, while keeping the user informed that something went wrong. 