### PR TITLE
Fix UnicodeDecodeError when decoding BLE device name

### DIFF
--- a/whad/ble/scanning.py
+++ b/whad/ble/scanning.py
@@ -118,9 +118,9 @@ class AdvertisingDevice:
         short_name = None
         for record in self.ad_records:
             if isinstance(record, AdvShortenedLocalName):
-                short_name = record.name.decode('utf-8')
+                short_name = record.name.decode('utf-8', errors='replace')
             elif isinstance(record, AdvCompleteLocalName):
-                complete_name = record.name.decode('utf-8')
+                complete_name = record.name.decode('utf-8', errors='replace')
 
         # Return discovered name (if any)
         if complete_name is not None:


### PR DESCRIPTION
This issue was encountered during scanning for ble devices using the `discover_devices` method :

`UnicodeDecodeError: 'utf-8' codec can't decode byte 0xcd in position 11`

BLE advertisement data is not guaranteed to be UTF-8 encoded (malformed packets for example) and previous implementation didn't check the bytes before decoding it.

This patch replaces the UTF-8 decoding with a safer decoding using:  `errors='replace' `