### PR TITLE
Fix: Scanner never yields discovered devices with default call path

### DIFF
--- a/whad/ble/scanning.py
+++ b/whad/ble/scanning.py
@@ -335,10 +335,10 @@ class AdvertisingDevicesDB:
 
                 # Register device if it matches our criterias
                 if filter_addr is not None and filter_addr.lower() == str(bd_address).lower():
-                    if self.register_device(device, update=updates) and updates:
+                    if self.register_device(device, update=updates):
                         devices.append(device)
                 elif filter_addr is None:
-                    if self.register_device(device, update=updates) and updates:
+                    if self.register_device(device, update=updates):
                         devices.append(device)
             except AdvDataError:
                 pass
@@ -361,10 +361,10 @@ class AdvertisingDevicesDB:
 
                 # Register device if it matches our criterias
                 if filter_addr is not None and filter_addr.lower() == str(bd_address).lower():
-                    if self.register_device(device, update=updates) and updates:
+                    if self.register_device(device, update=updates):
                         devices.append(device)
                 elif filter_addr is None:
-                    if self.register_device(device, update=updates) and updates:
+                    if self.register_device(device, update=updates):
                         devices.append(device)
 
             except AdvDataError:


### PR DESCRIPTION
## Summary

`AdvertisingDevicesDB.on_device_found()` has a logic bug that causes
`Scanner.discover_devices()` (and therefore `wble-central scan`) to
never yield any device on the default call path.

## Root cause

Four call sites in `whad/ble/scanning.py` use this guard:

```python
if self.register_device(device, update=updates) and updates:
    devices.append(device)
```

`register_device()` returns `True` when:
- the device is newly discovered, or
- the device is already known and `update=True` was passed AND the RSSI changed.

For the default scan (`scanner.discover_devices()` with no args →
`updates=False`), the `and updates` term is always `False`, so newly
discovered devices are **never appended** to the result list. The
`wble-central scan` command therefore prints only the table header
and no rows, even though packets arrive, `sniff()` yields them, and
the database is correctly populated.

## Fix

Remove the redundant `and updates`:

```python
if self.register_device(device, update=updates):
    devices.append(device)
```

`register_device()` already internalises the `updates` logic. The
corrected guard now:
- yields new devices on first discovery (default scan) ✔
- additionally yields RSSI-updates when `updates=True` is requested ✔

Applied to all four call sites (`BTLE_ADV_IND` + `BTLE_ADV_NONCONN_IND`,
each with / without `filter_addr`).

## Reproduction / Test

With a Butterfly-flashed nRF52840 Dongle on macOS (Python 3.11, WHAD 1.2.15
and current main):

```
$ wble-central -i uart0 scan
 RSSI Lvl  Type  BD Address        Extra info
(silent, no devices shown, even though advertisements are clearly flowing)
```

Debug traces confirm packets reach `Scanner.sniff()` and are decoded to
Scapy `BTLE_ADV_IND` packets correctly; the issue is purely in
`on_device_found()` afterwards.

With the fix applied, the same command produces expected output:

```
 RSSI Lvl  Type  BD Address        Extra info
[-072 dBm] [RND] 61:a1:a1:5a:7e:a9 name:"LE_WI-C100"
[-042 dBm] [RND] 69:a5:8a:39:61:42
[-041 dBm] [RND] fc:cf:dc:c0:38:c0
...
```

## Notes

- The `BTLE_SCAN_RSP` branch (line ~384) uses a different guard
  (`or updates`) and is left untouched.
- Minimal change, no new features.