### PR TITLE
Fixed BLE access address validation helper (#348)

### DIFF
--- a/tests/domain/ble/test_access_addr.py
+++ b/tests/domain/ble/test_access_addr.py
@@ -1,7 +1,9 @@
 """Test access address
 """
 import pytest
+from whad.ble.exceptions import InvalidHandleValueException
 from whad.ble.sniffing import AccessAddress, InvalidAccessAddressException
+from whad.ble.utils.phy import is_access_address_valid
 
 def test_creation():
     """Test creating an AccessAddress object
@@ -18,6 +20,21 @@ def test_update():
     aa.update(timestamp=9999, rssi=-60)
     assert aa.last_timestamp == 9999
     assert aa.last_rssi == -60
+
+def test_aa_less_two_transitions():
+    with pytest.raises(InvalidAccessAddressException):
+        _ = AccessAddress(0x00aaaaaa)
+
+def test_aa_two_transitions():
+    assert is_access_address_valid(0xd81278c2)
+
+def test_aa_seven_ones():
+    with pytest.raises(InvalidAccessAddressException):
+        _ = AccessAddress(0xd87f78c2)
+
+def test_aa_seven_zeroes():
+    with pytest.raises(InvalidAccessAddressException):
+        _ = AccessAddress(0xd80008c2)
 
 def test_bad_aa():
     """Test bad access address raises an exception

--- a/whad/ble/utils/phy.py
+++ b/whad/ble/utils/phy.py
@@ -134,20 +134,19 @@ def is_access_address_valid(aa):
         return True
     bb = aa
     for i in range(0,26):
-        if (bb & 0x3F) == 0 or (bb & 0x3F) == 0x3F:
+        if (bb & 0x7F) == 0 or (bb & 0x7F) == 0x7F:
             return False
         bb >>= 1
     bb = aa
     t = 0
     a = (bb & 0x80000000)>>31
-    for i in range(30,0,-1):
+    for i in range(30,25,-1):
         if (bb & (1<<i)) >> i != a:
             a = (bb & (1<<i))>>i
             t += 1
-            if t>24:
-                return False
-        if (i<26) and (t<2):
-            return False
+
+    if t<2:
+        return False
     return True
 
 


### PR DESCRIPTION
BLE access address validation helper did not follow the Bluetooth specification's AA constraints checks, leading to valid AA being considered invalid and rejected by the framework.