### PR TITLE
Removed the `--disable-chaining` option (fixes #356)

### DIFF
--- a/whad/cli/app.py
+++ b/whad/cli/app.py
@@ -326,14 +326,6 @@ class CommandLineApp(ArgumentParser):
                 help='specifies the WHAD interface to use',
             )
 
-        self.add_argument(
-            '--disable-chaining',
-            dest='disable_chaining',
-            action='store_true',
-            default=False,
-            help='Disable WHAD tool chaining'
-        )
-
         # Add our default option --no-colorfself
         self.add_argument(
             '--no-color',
@@ -610,10 +602,6 @@ class CommandLineApp(ArgumentParser):
 
         :return bool: True if stdout is piped, False otherwise
         """
-        if self.__args.disable_chaining:
-            # we disabled WHAD tool chaining feature
-            return False
-
         if not sys.stdout.isatty():
             # If we are on a Linux system, check if we are redirected to
             # /dev/null, in this case we consider we are not *really* piped


### PR DESCRIPTION
The `--disable-chaining` option has been introduced in a pull request that has been merged by error, creating a duplicate option as `--force-stdout` already provides the same feature with better safeguards.

This PR removes this option from WHAD's CLI tools, leaving the `--force-stdout` option the only one available for CLI tools that may need it.