### PR TITLE
fix: replace undefined 'data' with 'payload' in TCPSocketDevice.write()

### DIFF
--- a/whad/device/tcp.py
+++ b/whad/device/tcp.py
@@ -174,7 +174,7 @@ class TcpSocket(Device):
         :param bytes payload: Data to write
         :returns: number of bytes written to the device
         """
-        logger.debug("sending data to TCP socket: %s", data.hex())
+        logger.debug("sending data to TCP socket: %s", payload.hex())
         if not self.__opened:
             raise WhadDeviceNotReady()
 


### PR DESCRIPTION
closes #360