### PR TITLE
Fixing SMP error & minor fixes 

### DIFF
--- a/whad/ble/profile/device.py
+++ b/whad/ble/profile/device.py
@@ -10,7 +10,7 @@ for a given connected device:
 """
 import logging
 from struct import unpack
-from time import sleep
+import time
 from typing import Iterator, Optional, Union, Type, TypeVar, List
 
 from whad.ble.profile import PrimaryService
@@ -599,16 +599,24 @@ class PeripheralDevice(GenericProfile):
                 crypto_material.ltk.ediv
             )
 
-    def pairing(self, pairing=None):
+    def pairing(self, pairing=None, timeout: float = 30.0):
         """Trigger a pairing according to provided parameters.
         Default parameters will be used if pairing parameter is None.
+
+        :param pairing: Pairing parameters.
+        :param timeout: Maximum time in seconds to wait for pairing to complete.
+
         """
         if not self.__smp.initiate_pairing(parameters=pairing):
             return False
 
+        start = time.time()
         while not self.__smp.is_pairing_done():
-            sleep(0.1)
+            time.sleep(0.1)
             if self.__smp.is_pairing_failed():
+                return False
+            if (time.time() - start) > timeout:
+                logger.warning("pairing timed out after %.1fs", timeout)
                 return False
 
         self.__smp.reset_state()

--- a/whad/ble/stack/l2cap/__init__.py
+++ b/whad/ble/stack/l2cap/__init__.py
@@ -104,15 +104,12 @@ class L2CAPLayer(ContextualLayer):
 
     def on_cmd_packet(self, packet):
         """Handle L2CAP Connection Parameter Update Requests.
-
-        This command is rejected by default.
         """
         if L2CAP_Connection_Parameter_Update_Request in packet:
-            logger.debug("[l2cap] Received a L2CAP Connection Parameter Update Request, rejecting")
-            # Reject it
+            logger.debug("[l2cap] Received a L2CAP Connection Parameter Update Request, accepting")
             self.send("ll", L2CAP_Hdr()/L2CAP_CmdHdr(
                 id=packet[L2CAP_CmdHdr].id
-            )/L2CAP_Connection_Parameter_Update_Response(move_result=1))
+            )/L2CAP_Connection_Parameter_Update_Response(move_result=0))
 
     def get_fragments(self, data: bytes):
         """Split data into fragments based on MTU

--- a/whad/ble/stack/smp/__init__.py
+++ b/whad/ble/stack/smp/__init__.py
@@ -2334,7 +2334,7 @@ class SMPLayer(Layer):
             if self.state.responder.is_key_distribution_complete():
                 self.perform_key_distribution()
 
-        elif self.state.state == SecurityManagerState.STATE_LESC_DHK_CHECK_SENT:
+        elif self.state.state in (SecurityManagerState.STATE_LESC_DHK_CHECK_SENT, SecurityManagerState.STATE_LESC_DHK_CHECK_RECVD):
             logger.info('[smp] Channel is now successfully encrypted')
             self.perform_key_distribution()
         else:

--- a/whad/device/hci/__init__.py
+++ b/whad/device/hci/__init__.py
@@ -440,8 +440,10 @@ class Hci(VirtualDevice):
 
 
         except (BrokenPipeError, OSError) as err:
-            print(err)
-            logger.error("Error, waiting...")
+            # Prevent possible close() mid-read
+            if not self.__opened or self.__socket is None:
+                raise WhadDeviceDisconnected()
+            logger.error("[hci] read error: %s", err)
             sleep(1)
 
     def _wait_response(self, timeout=None):

--- a/whad/device/hci/__init__.py
+++ b/whad/device/hci/__init__.py
@@ -43,7 +43,7 @@ from whad.scapy.layers.hci import HCI_VERSIONS, BT_MANUFACTURERS, \
 
 # Whad
 from whad.exceptions import WhadDeviceNotFound, WhadDeviceNotReady, WhadDeviceAccessDenied, \
-    WhadDeviceUnsupportedOperation, WhadDeviceError
+    WhadDeviceUnsupportedOperation, WhadDeviceError, WhadDeviceDisconnected
 
 # Whad hub
 from whad.hub.discovery import Domain
@@ -374,14 +374,21 @@ class Hci(VirtualDevice):
         """
         if not self.__opened:
             raise WhadDeviceNotReady()
+
+        # Avoid None.recv() (ran into multiples times)
+        sock = self.__socket
+        if sock is None:
+            raise WhadDeviceDisconnected()
         try:
             # We assume here that we can determine if there is something to read
             # by calling readable without locking our socket
-            if self.__socket is not None and self.__socket.readable(0.1):
+            if sock.readable(0.1):
                 # Lock our socket to catch the awaiting event
                 self.__lock.acquire()
-                event = self.__socket.recv()
-                self.__lock.release()
+                try:
+                    event = sock.recv()
+                finally:
+                    self.__lock.release()
                 if event.type == 0x4 and event.code in (0xe, 0xf, 0x13):
                     self.__hci_responses.put(event)
                 else:


### PR DESCRIPTION
A simple pairing script as ``examples/ble/ble_central_pairing.py`` led to this error (hci & butterfly)

```whad.ble.stack.smp ERROR [smp] Received an unexpected notification (LL_START_ENC_RSP)```

The commit 3c7b235 is fixing this.

When encryption starts (``LL_START_ENC_RSP``), ``on_channel_encrypted()`` is called. The old code only handled ``DHK_CHECK_SENT``. On central roles scripts, the state was ``DHK_CHECK_RECVD`` which was not excepted.

The 3 others commits are fixing some errors / bad handled code during my tests, its up to you.

NOTE: there is an issue with the discovery when used just after the connect() method (surely a race), i didn't added it.